### PR TITLE
Edit breadcrumb when users edits their account MLN-146

### DIFF
--- a/app/views/layouts/_breadcrumb.html.erb
+++ b/app/views/layouts/_breadcrumb.html.erb
@@ -1,7 +1,7 @@
 <div id="breadcrumb">
 	<%= link_to "Home", "/app#/teacher_sets" %> <i class="fa fa-angle-right"></i>
 	<% case request.fullpath %>
-	<% when "/account" %>
+	<% when "/account", "/users/edit" %>
 	Account
 	<% when "/help" %>
 	Help


### PR DESCRIPTION
The breadcrumbs now say "Account", similar to when you go to /account
![screen shot 2018-08-06 at 4 37 54 pm](https://user-images.githubusercontent.com/1825103/43739763-2637c166-9997-11e8-9165-44725d3725b4.png)
