### PR TITLE
Adds development.log to CloudWatch

### DIFF
--- a/.ebextensions/01_cloudwatch_agent_config.config
+++ b/.ebextensions/01_cloudwatch_agent_config.config
@@ -5,8 +5,8 @@ files:
     group: root
     content: |
       [application_log]
-      file = /var/app/current/log/mylibrarynyc.log*
-      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/log/mylibrarynyc-app.log"]]}`
+      file = /var/app/support/logs/development.log
+      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/support/logs/development.log"]]}`
       log_stream_name = {instance_id}
 
 commands:

--- a/.ebextensions/01_cloudwatch_agent_config.config
+++ b/.ebextensions/01_cloudwatch_agent_config.config
@@ -5,8 +5,8 @@ files:
     group: root
     content: |
       [application_log]
-      file = /var/app/support/logs/development.log
-      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/support/logs/development.log"]]}`
+      file = /var/app/current/log/development.log
+      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/log/development.log"]]}`
       log_stream_name = {instance_id}
 
 commands:


### PR DESCRIPTION
This PR updates the CloudWatch streaming log configuration to properly reference the application log: `development.log`.

See on development:
https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/elasticbeanstalk/my-library-nyc-app-development/var/app/current/log/development.log;stream=i-0264c5b15f84ade14;start=2018-08-07T20:09:00Z