### PR TITLE
Send school's address as patron's address MLN-165

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,11 +108,20 @@ class User < ActiveRecord::Base
     query = {
       'names' => [last_name.upcase + ', ' + first_name.upcase],
       'emails' => [email],
-      'barcodes' => [self.assign_barcode.to_s],
-      'patronType' => 151,
+      'patronType' => patron_type,
       'patronCodes' => {
         'pcode4' => -1
-      }
+      },
+      'barcodes' => [self.assign_barcode.to_s],
+      'addresses': [
+        {
+          'lines': [
+            "#{school.address_line_1}",
+            "#{school.address_line_2}"
+          ],
+          'type': 'a'
+        }
+      ],
     }
     response = HTTParty.post(
       ENV['PATRON_MICROSERVICE_URL_V02'],
@@ -193,5 +202,9 @@ class User < ActiveRecord::Base
       )
       raise InvalidResponse, "Invalid status code of: #{response.code}"
     end
+  end
+
+  def patron_type
+    school.borough == 'QUEENS' ? 149 : 151
   end
 end

--- a/test/factories/school_factory.rb
+++ b/test/factories/school_factory.rb
@@ -1,11 +1,18 @@
 class Cranky::Factory
-  # Simple factory method to create a user instance, you would call this via crank(:user)
   def school
-    School.new do |u|
-      u.id  = [1,1,1,1].map!{|x| (0..9).to_a.sample}.join.to_i
-      u.name  =   "Antonia Pantoja Preparatory Academy: A College Boar..."        
-      u.code  = 'zx' + rand.to_s[2..4]             
-      u.active =  true
-    end
+    define name: "Queens Academy: College Prep",
+           address_line_1: '100 Main St',
+           address_line_2: 'Example, NY 10000',
+           code: 'z' + rand.to_s[2..4],
+           borough: 'Manhattan',
+           active: true
+  end
+
+  def queens_school
+    inherit(:school, code: 'zq' + rand.to_s[2..4], borough: 'QUEENS')
+  end
+
+  def bronx_school
+    inherit(:school, code: 'zx' + rand.to_s[2..4], borough: 'BRONX')
   end
 end

--- a/test/factories/user_factory.rb
+++ b/test/factories/user_factory.rb
@@ -1,16 +1,19 @@
 class Cranky::Factory
-  # Simple factory method to create a user instance, you would call this via crank(:user)
   def user
-    User.new do |u|
-      u.id = rand(10...100000) 
-      u.first_name  = options[:first_name] || Faker::Name.first_name 
-      u.last_name  =  options[:last_name] || Faker::Name.last_name         
-      u.email  = ('a'..'z').to_a.shuffle[0, 8].join + Time.now.to_i.to_s + '@schools.nyc.gov'             
-      u.pin =  options[:pin] || [1, 1, 1, 1].map! { (0..9).to_a.sample }.join
-      u.barcode = 27777099999998
-      u.school_id = options[:school_id] || 9999
-      u.password = 'password123'
-      u.password_confirmation = 'password123'
-    end
+    define first_name: options[:first_name] || Faker::Name.first_name,
+           last_name: options[:last_name] || Faker::Name.last_name,
+           email: ('a'..'z').to_a.shuffle[0, 8].join + Time.now.to_i.to_s + '@schools.nyc.gov',
+           password: 'password123',
+           password_confirmation: 'password123',
+           pin: 1234,
+           school: queens_school
+  end
+
+  def queens_user
+    inherit(:user)
+  end
+
+  def bronx_user
+    inherit(:user, school: bronx_school)
   end
 end

--- a/test/integration/user_flow_test.rb
+++ b/test/integration/user_flow_test.rb
@@ -1,41 +1,29 @@
 require 'test_helper'
 
 class UserFlowTest < ActionDispatch::IntegrationTest
- 
-setup do 
-   @school = crank!(:school)
-   @user = crank!(:user, school_id: @school.id)
-end
-
-  # Test that generated barcode is a 14-digit string, starting with '27777'.
   test "user method assign_barcode increments last valid barcode by 1" do
-    user_two = crank!(:user, school_id: @school.id)
-    @user.assign_barcode
-    assert(@user.barcode == 27777099999999)
+    user_one = crank!(:user, barcode: 27777000000099)
+    user_two = crank(:user)
+    user_two.assign_barcode
+    assert(user_two.barcode == 27777000000100)
   end
 
-[generate_email].each do |new_email|
-  test 'create new user record and send request to microservice' do
-    get '/users/signup'
-    assert_select 'h1', 'Sign Up'
-    post '/users',
-    user: {
-      first_name: @user.first_name,
-      last_name: @user.last_name,
-      email: new_email,
-      pin: @user.pin,
-      school_id: @school.id
-    }
-    assert_response :redirect
-    follow_redirect!
-    assert 'div', 'Welcome! You have signed up successfully'
+  [generate_email].each do |new_email|
+    test 'create new user record and send request to microservice' do
+      user = crank!(:user, barcode: 27777000000000)
+      get '/users/signup'
+      assert_select 'h1', 'Sign Up'
+      post '/users',
+      user: {
+        first_name: user.first_name,
+        last_name: user.last_name,
+        email: new_email,
+        pin: user.pin,
+        school_id: user.school_id
+      }
+      assert_response :redirect
+      follow_redirect!
+      assert 'div', 'Welcome! You have signed up successfully'
+    end
   end
-end 
-
-
-  # Test that generated barcode is a 14-digit string, starting with '27777'.
-  # test "user method generate_barcode returns valid string" do
-  #   assert(/\A2777\d{10}\z/ === user.generate_barcode)
-  # end
-
 end


### PR DESCRIPTION
Include the patron's address in the POST request to the Patron Creator Service.

The address data should come from the patron's school.