### PR TITLE
Use different syntax for JS string interpolation to fix prod

### DIFF
--- a/app/assets/javascripts/active_admin_custom.js
+++ b/app/assets/javascripts/active_admin_custom.js
@@ -112,10 +112,10 @@ $( document ).ready(function() {
 
 function activateSchool(schoolId, activate) {
   if (activate == true){
-    $(`#activate-school-${schoolId}-container`).hide();
-    $(`#inactivate-school-${schoolId}-container`).show();
+    $('#activate-school-' + schoolId + '-container').hide();
+    $('#inactivate-school-' + schoolId + '-container').show();
   } else {
-    $(`#inactivate-school-${schoolId}-container`).hide();
-    $(`#activate-school-${schoolId}-container`).show();
+    $('#inactivate-school-' + schoolId + '-container').hide();
+    $('#activate-school-' + schoolId + '-container').show();
   }
 };


### PR DESCRIPTION
Asset compilation via the Uglifier gem was failing on production.  In this PR, we use an older syntax for JS compilation that will work with the version of JS that Uglifier uses.

This is already merged into Production, so this PR gets it into Dev and eventually it will get picked up in QA (necessary to prevent merge conflicts when QA is merged into Master).