### PR TITLE
Add ebextension for ssl

### DIFF
--- a/.ebextensions/07_https-nypl-digital-dev.config
+++ b/.ebextensions/07_https-nypl-digital-dev.config
@@ -1,0 +1,4 @@
+option_settings:
+  aws:elb:loadbalancer:
+    LoadBalancerHTTPSPort: 443
+    SSLCertificateId: arn:aws:acm:us-east-1:946183545209:certificate/d38c5c82-708d-4942-a4cc-bc4985a9a4c7


### PR DESCRIPTION
We set up SSL on the load balancer.  Now we're telling elastic beanstalk about the SSL certificate, by putting it into code.