### PR TITLE
form doesn't not need to be disabled

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -69,7 +69,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign Up", :class=> "button", :id =>'sign_up_button',   disabled: true %>
+    <%= f.submit "Sign Up", :class=> "button", :id =>'sign_up_button' %>
   </div>
 <% end %>
 


### PR DESCRIPTION
- There is no need to disable the submit button by default for the following reasons:

1.  Each client side validation will automatically disable the button if the data is incorrectly validated  
2. For the case of receiving an error from the token service or check_email request, the submit button will also be disabled 