### PR TITLE
Send hold cancellation email even if no reason MLN-236

### DIFF
--- a/app/mailers/hold_mailer.rb
+++ b/app/mailers/hold_mailer.rb
@@ -42,14 +42,14 @@ class HoldMailer < ActionMailer::Base
   end
 
 
-  def status_change(hold, status, message)
+  def status_change(hold, status, details)
     @hold = hold
     @hold.status = status
     @user = hold.user
     @teacher_set = hold.teacher_set
-    @message = message
+    @details = details
     Rails.logger.debug("status_change: About to send hold order notification email to #{@user.email}")
-    mail(:to => @user.contact_email, :subject => "Your teacher set order status for #{@teacher_set.title}")
+    mail(:to => @user.contact_email, :subject => "Order #{@hold.status} | Your teacher set order for #{@teacher_set.title}")
   end
 
 end

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -81,6 +81,7 @@ class Hold < ActiveRecord::Base
   end
 
   def send_admin_notification_email
+    return if Rails.env.development? || Rails.env.local?
     HoldMailer.admin_notification(self).deliver
   end
 

--- a/app/models/hold_change.rb
+++ b/app/models/hold_change.rb
@@ -8,15 +8,15 @@ class HoldChange < ActiveRecord::Base
   belongs_to :admin_user
 
   after_save :do_after_save
-  
+
   def do_after_save
     update_hold
     send_change_status_email
   end
-  
+
   def send_change_status_email
-    # deliver email if there's a comment and status has been changed to error, pending, or closed
-    HoldMailer.status_change(hold, status, comment).deliver if !comment.blank? and ['error', 'pending', 'closed', 'cancelled'].include? status
+    # deliver email if status has been changed to error, pending, closed, or cancelled
+    HoldMailer.status_change(hold, status, comment).deliver if ['error', 'pending', 'closed', 'cancelled'].include? status
   end
 
   def update_hold
@@ -24,5 +24,5 @@ class HoldChange < ActiveRecord::Base
     hold.status = status
     hold.save
   end
-  
+
 end

--- a/app/views/hold_mailer/status_change.html.erb
+++ b/app/views/hold_mailer/status_change.html.erb
@@ -1,12 +1,18 @@
-<p><%= @message %></p>
+Your order status for <%= @teacher_set.title %> is <%= @hold.status %>.
+
+<% if @details.present? %>
+  <p>
+    Details: <%= @details %>
+  </p>
+<% end %>
 
 <p>
   Your order ID is <strong><%= @hold.access_key %></strong>. You can view the details of your order here:<br />
-  <%= link_to "#{hold_url(@hold.access_key)}", hold_url(@hold.access_key) %> 
+  <%= link_to "#{hold_url(@hold.access_key)}", hold_url(@hold.access_key) %>
 </p>
 
 <p>
   Thank You,<br />
   MyLibraryNYC<br />
-  <%= link_to "#{root_url}", root_url %> 
+  <%= link_to "#{root_url}", root_url %>
 </p>

--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -38,5 +38,5 @@ MyLibraryNYC::Application.configure do
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
   config.action_mailer.perform_deliveries = true
 
-  Rails.env = 'development'
+  Rails.env = 'local'
 end


### PR DESCRIPTION
Previously, if the user didn't enter a reason for cancellation, they didn't receive an email.  We want the email to be sent in both situations.

I also added local.rb because emails weren't being sent without this being set: `config.action_mailer.default_url_options = { :host => 'localhost:3000' }` and without that file, it wasn't set.

I also turned off `send_admin_notification_email` if the user is in a local or development environment.

# Order & Cancellation Emails
![screen shot 2018-08-31 at 3 20 02 pm](https://user-images.githubusercontent.com/1825103/44932046-cf6f9800-ad31-11e8-8505-c4452256e0dc.png)

# Cancellation Email
![screen shot 2018-08-31 at 3 20 11 pm](https://user-images.githubusercontent.com/1825103/44932045-cf6f9800-ad31-11e8-8b7b-f3bf9d41a9a0.png)

