### PR TITLE
Ability to add user via MLN admin interface MLN-279

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ActiveRecord::Base
   validates_format_of :first_name, :last_name, :with => /\A[^0-9`!@;#\$%\^&*+_=\x00-\x19]+\z/
   validates_format_of :alt_email,:with => Devise::email_regexp, :allow_blank => true, :allow_nil => true
   validates :alt_email, uniqueness: true, allow_blank: true, allow_nil: true
-  validates :pin, :presence => true, format: { with: /\A\d+\z/, message: "requires numbers only." },
+  validates :pin, :presence => true, format: { with: /\A\d+\z/, message: "may only contain numbers" },
     length: { is: 4, message: 'must be 4 digits.' }, on: :create
   validate :validate_pin_pattern, on: :create
 
@@ -86,7 +86,7 @@ class User < ActiveRecord::Base
   # error message if PIN is invalid:
   # "PIN is not valid : PIN is trivial"
   def validate_pin_pattern
-    if pin.scan(/(.)\1{2,}/).empty? && pin.scan(/(..)\1{1,}/).empty? == true
+    if pin && pin.scan(/(.)\1{2,}/).empty? && pin.scan(/(..)\1{1,}/).empty? == true
       true
     else
       errors.add(:pin, 'does not meet our requirements. Please try again.')
@@ -112,7 +112,7 @@ class User < ActiveRecord::Base
         'pcode3' => pcode3,
         'pcode4' => pcode4
       },
-      'barcodes' => [self.assign_barcode.to_s],
+      'barcodes' => [self.barcode.present? ? self.barcode : self.assign_barcode.to_s],
       'addresses': [
         {
           'lines': [

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -29,7 +29,7 @@ class UserTest < ActiveSupport::TestCase
     test 'user model cannot be created without pin' do
       @user.pin = ""
       @user.save
-      assert_equal(["can't be blank", "requires numbers only.", "must be 4 digits."], @user.errors.messages[:pin])
+      assert_equal(["can't be blank", "may only contain numbers", "must be 4 digits."], @user.errors.messages[:pin])
     end
   end
 


### PR DESCRIPTION
There is a page for adding a new user via the admin dashboard:
<img width="991" alt="screen shot 2018-09-11 at 9 02 22 am" src="https://user-images.githubusercontent.com/1825103/45364049-29c8ee00-b5a7-11e8-8516-4a2ad2859dc6.png">

The required fields are the ones that are the same from the sign-up-form:
<img width="975" alt="screen shot 2018-09-11 at 9 05 17 am" src="https://user-images.githubusercontent.com/1825103/45364066-2f263880-b5a7-11e8-8090-6d1d2496c5dd.png">

The system automatically assigns a barcode if none is assigned by the admin:
<img width="986" alt="screen shot 2018-09-11 at 9 35 46 am" src="https://user-images.githubusercontent.com/1825103/45364070-31889280-b5a7-11e8-9576-6b234f118924.png">

The admin can edit the user:
<img width="989" alt="screen shot 2018-09-11 at 9 35 57 am" src="https://user-images.githubusercontent.com/1825103/45364074-33eaec80-b5a7-11e8-99bf-9e24946640c6.png">
