### PR TITLE
Make the timeout check IE compatible

### DIFF
--- a/app/views/layouts/_timeout.html
+++ b/app/views/layouts/_timeout.html
@@ -1,19 +1,22 @@
 <script>
   function PeriodicalQuery() {
-    var request = new XMLHttpRequest();
-    request.onload = function (event) {
-      if (request.response['timeout_status'] == 'no_current_user') {
-        return;
-      } else if (request.response['timeout_status'] == 'timeout_warning') {
-        $('#timeout-warning').slideDown('fast');
-      } else if (request.response['timeout_status'] == 'timed_out') {
-        window.location.href = '/users/start';
-      }
-    };
-    request.open('GET', '/timeout_check', true);
-    request.responseType = 'json';
-    request.send();
+    $.ajax({
+      url: '/timeout_check',
+      type: 'GET',
+      success: handleResponse
+    });
+  };
+
+  function handleResponse(response) {
+    if (response['timeout_status'] == 'no_current_user') {
+      return;
+    } else if (response['timeout_status'] == 'timeout_warning') {
+      $('#timeout-warning').slideDown('fast');
+    } else if (response['timeout_status'] == 'timed_out') {
+      window.location.href = '/users/start';
+    }
     setTimeout(PeriodicalQuery, (5 * 1000 * 60));
-  }
+  };
+
   setTimeout(PeriodicalQuery, (5 * 1000 * 60));
 </script>


### PR DESCRIPTION
IE couldn't handle the XMLHttpRequest format, so I changed it to AJAX.

If you want to test it locally, use this in sessions_controller.rb:
```
  def max_session_duration
    20.seconds
  end

  def timeout_warning_duration
    10.seconds
  end
```
and this line twice in _timeout.html:
```
setTimeout(PeriodicalQuery, (3 * 1000));  //three seconds rather than 5 minutes
```