### PR TITLE
Remove delete_book endpoint MLN-255

### DIFF
--- a/app/controllers/api/v1/bibs_controller.rb
+++ b/app/controllers/api/v1/bibs_controller.rb
@@ -1,17 +1,31 @@
 class Api::V1::BibsController < ApplicationController
-  def create_or_update_book
-    render json: { status: 200, book_id: 0 }.to_json
+  def create_or_update_teacher_sets
+    render status: 200, json: {
+      teacher_sets: [
+        {
+          id: 1,
+          title: 'Example title 1'
+        },
+        {
+          id: 2,
+          title: 'Example title 2'
+        }
+      ]
+    }.to_json
   end
 
-  def create_or_update_teacher_set
-    render json: { status: 200, teacher_set_id: 0 }.to_json
-  end
-
-  def delete_book
-    render json: { status: 200, book_id: 0 }.to_json
-  end
-
-  def delete_teacher_set
-    render json: { status: 200, teacher_set_id: 0 }.to_json
+  def delete_teacher_sets
+    render status: 200, json: {
+      teacher_sets: [
+        {
+          id: 1,
+          title: 'Example title 1'
+        },
+        {
+          id: 2,
+          title: 'Example title 2'
+        }
+      ]
+    }.to_json
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,10 +80,8 @@ MyLibraryNYC::Application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      post '/teacher_set' => 'bibs#create_or_update_teacher_set'
-      delete '/teacher_set' => 'bibs#delete_teacher_set'
-      post '/book' => 'bibs#create_or_update_book'
-      delete '/book' => 'bibs#delete_book'
+      post '/teacher_sets' => 'bibs#create_or_update_teacher_sets'
+      delete '/teacher_sets' => 'bibs#delete_teacher_sets'
     end
   end
 

--- a/test/functional/api/v1/bibs_controller_test.rb
+++ b/test/functional/api/v1/bibs_controller_test.rb
@@ -5,23 +5,13 @@ class Api::BibsControllerTest < ActionController::TestCase
     @controller = Api::V1::BibsController.new
   end
 
-  test "should create or update a teacher set when given a bib number" do
-    post 'create_or_update_teacher_set'
+  test "should create or update teacher sets when given a bib number" do
+    post 'create_or_update_teacher_sets'
     assert_response :success
   end
 
-  test "should delete a teacher set when given a bib number" do
-    delete 'delete_teacher_set'
-    assert_response :success
-  end
-
-  test "should create or update a book when given a bib number" do
-    post 'create_or_update_book'
-    assert_response :success
-  end
-
-  test "should delete a book when given a bib number" do
-    delete 'delete_book'
+  test "should delete teacher sets when given a bib number" do
+    delete 'delete_teacher_sets'
     assert_response :success
   end
 end


### PR DESCRIPTION
I changed the routes now that we're sending teacher sets for create/update and delete in bulk.
I removed the update-book endpoint.
# Create/Update (HTTP POST method)
<img width="905" alt="screen shot 2018-10-01 at 3 20 46 pm" src="https://user-images.githubusercontent.com/1825103/46310585-c6225700-c58d-11e8-9d16-0c00e7983b3a.png">

# Delete (HTTP DELETE method)
<img width="909" alt="screen shot 2018-10-01 at 3 20 06 pm" src="https://user-images.githubusercontent.com/1825103/46310586-c6225700-c58d-11e8-8609-43d1744845cd.png">
