### PR TITLE
Clean up teacher set records MLN-299

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -11,6 +11,8 @@ class Book < ActiveRecord::Base
 	has_many :teacher_set_books, :dependent => :destroy
 	has_many :teacher_sets, through: :teacher_set_books
 
+  validates_uniqueness_of :bnumber
+
   validate do |book|
     BookValidator.new(book).validate
   end
@@ -20,7 +22,7 @@ class Book < ActiveRecord::Base
   def populate_missing_data
     if self.details_url.nil?
       puts "populate missing data for #{self.inspect}"
-      if !self.catalog_choice.nil? && !self.catalog_choice.empty? 
+      if !self.catalog_choice.nil? && !self.catalog_choice.empty?
         # puts "populate missing data for #{self.inspect} from #{self.catalog_choice}"
 
         item = self.class.catalog_item self.catalog_choice
@@ -47,7 +49,7 @@ class Book < ActiveRecord::Base
       q[:title] = self.title
       q[:author] = self.statement_of_responsibility unless self.statement_of_responsibility.nil? || self.statement_of_responsibility.empty?
     end
-    
+
     self.class.catalog_items_by_query q
   end
 
@@ -65,7 +67,7 @@ class Book < ActiveRecord::Base
 		self.update_attributes :details_url => item['details_url']
 
 		self.update_attributes :title => item['title'], :sub_title => item['sub_title'], :publication_date => item['publication_date'], :call_number => item['call_number'], :description => item['description'], :statement_of_responsibility => item['statement_of_responsibility']
-		
+
 		self.update_attributes :format => item['format']['name'] unless item['format'].nil?
 		self.update_attributes :physical_description => item['physical_description'].join(';') unless item['physical_description'].nil?
 		self.update_attributes :notes => item['notes'].join(';') unless item['notes'].nil?
@@ -90,20 +92,20 @@ class Book < ActiveRecord::Base
   def self.catalog_items_by_query(params, scrape_fallback=false)
     q = []
     # if !self.isbn.nil? && !self.isbn.empty?
-    if !params[:isbn].nil? 
+    if !params[:isbn].nil?
       q << 'isbn:' + params[:isbn]
     else
       q << "title:(#{params[:title]})" unless params[:title].nil?
       q << "author:(#{params[:author]})" unless params[:author].nil? || params[:author].empty?
     end
-  
+
     # puts "query: #{q.inspect}"
 
-    resp = self.api_call 'titles', {:q => q.join(' '), :library => 'nypl', :search_type => 'custom'} 
+    resp = self.api_call 'titles', {:q => q.join(' '), :library => 'nypl', :search_type => 'custom'}
 
     if (!resp.keys.include?('titles') || resp['titles'].empty?) && scrape_fallback
       scrape_url = "http://#{CATALOG_DOMAIN}/search~S1/?searchtype=i&searcharg=#{params[:isbn]}"
-      
+
       rows = self.scrape_css scrape_url, '.bibDetail tr', 1.day
       rows.each do |n|
         # puts " Considering row: #{n}"

--- a/app/models/teacher_set.rb
+++ b/app/models/teacher_set.rb
@@ -20,6 +20,8 @@ class TeacherSet < ActiveRecord::Base
   accepts_nested_attributes_for :books, :allow_destroy => true
   validates_associated :books
 
+  validates_uniqueness_of :bnumber
+
   before_create :make_slug
 
   AVAILABILITY_LABELS = {'available' => 'Available', 'unavailable' => 'Checked Out'}

--- a/config/application.yml
+++ b/config/application.yml
@@ -6,7 +6,7 @@ case ENV['RAILS_ENV']
 
 when 'local'
 
-  ENV['DATABASE_URL'] = "postgresql://localhost/postgres"
+  ENV['DATABASE_URL'] = "postgresql://localhost/mylibnyc_local"
   ENV['SECRET_KEY_BASE'] = AwsDecrypt.decrypt_kms("AQECAHjqALewp8JBJNxIQvR4oY795dyG7INaGR1glMsTEgetggAAAOMwgeAGCSqGSIb3DQEHBqCB0jCBzwIBADCByQYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAxjUy6F+DQ0NZ0NH/UCARCAgZv7/TEPBAow+srmtwcgFdEMbthnWmJVMZmR+NyMl0gaoqiQyYqJvAwbmgwDBYQKeVm1qSqvbKJchR86HQJ2icnUCH/OShiQs3H8Bo+ddnc97v/mhJx8MlR6fYyxZF79VmhYvfIaRO1HwTyCMjbV7dGbVw8kj0xZG7tXXyAubcdBMeJrnja5GghViu+I3VaZxQz1/RwbMhK5x49M7A==")
   ENV['PATRON_MICROSERVICE_URL_V01'] = "https://dev-platform.nypl.org/api/v0.1/patrons"
   ENV['PATRON_MICROSERVICE_URL_V02'] = "https://dev-platform.nypl.org/api/v0.2/patrons"

--- a/db/migrate/20180926114647_add_bnumber_to_books.rb
+++ b/db/migrate/20180926114647_add_bnumber_to_books.rb
@@ -1,0 +1,5 @@
+class AddBnumberToBooks < ActiveRecord::Migration
+  def up
+    add_column :books, :bnumber, :string, :limit => 20
+  end
+end

--- a/db/migrate/20180926134547_clean_up_books_and_teacher_sets.rb
+++ b/db/migrate/20180926134547_clean_up_books_and_teacher_sets.rb
@@ -1,0 +1,16 @@
+class CleanUpBooksAndTeacherSets < ActiveRecord::Migration
+  def up
+    ActiveRecord::Base.transaction do
+      # Teacher sets already have bnumbers after testing each of the teacher_sets,
+      # I've found that teacher_set.update_bnumber! would return the same result as existing bnumbers
+      # so we're only going to update the bnumbers of books in this migration.
+      Book.all.each do |book|
+        puts "Updating bnumber for book ##{book.id}"
+        book.update_bnumber!
+      end
+
+      puts "Calling rake task to clean up teacher sets and books"
+      Rake::Task['cleanup:bib_records'].invoke('book teacher_set')
+    end
+  end
+end

--- a/db/migrate/20180928145516_add_index_to_teacher_sets_and_books.rb
+++ b/db/migrate/20180928145516_add_index_to_teacher_sets_and_books.rb
@@ -1,0 +1,6 @@
+class AddIndexToTeacherSetsAndBooks < ActiveRecord::Migration
+  def change
+    add_index :teacher_sets, ["bnumber"], :name => "index_teacher_sets_bnumber", :unique => true
+    add_index :books, ["bnumber"], :name => "index_books_bnumber", :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180924150408) do
+ActiveRecord::Schema.define(:version => 20180928145516) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -62,8 +62,10 @@ ActiveRecord::Schema.define(:version => 20180924150408) do
     t.string   "cover_uri"
     t.datetime "created_at",                  :null => false
     t.datetime "updated_at",                  :null => false
+    t.string   "bnumber"
   end
 
+  add_index "books", ["bnumber"], :name => "index_books_bnumber", :unique => true
   add_index "books", ["title"], :name => "index_books_title"
 
   create_table "boroughs", :force => true do |t|
@@ -193,6 +195,7 @@ ActiveRecord::Schema.define(:version => 20180924150408) do
   end
 
   add_index "teacher_sets", ["availability"], :name => "index_teacher_sets_availaibilty"
+  add_index "teacher_sets", ["bnumber"], :name => "index_teacher_sets_bnumber", :unique => true
   add_index "teacher_sets", ["grade_begin", "grade_end"], :name => "index_teacher_sets_grades"
   add_index "teacher_sets", ["lexile_begin", "lexile_end"], :name => "index_teacher_sets_lexile"
   add_index "teacher_sets", ["primary_subject"], :name => "index_primary_subject"

--- a/lib/catalog_item_methods.rb
+++ b/lib/catalog_item_methods.rb
@@ -51,6 +51,16 @@ module CatalogItemMethods
 
       ret
     end
+
+    def update_bnumber!
+      if self.details_url && self.details_url.include?('record=')
+        self.bnumber = self.details_url.split('record=')[1].split('~')[0]
+        self.save
+      elsif self.details_url && self.details_url.include?('bibliocommons.com/item/show/') && self.details_url[-2..-1] == '052'
+        self.bnumber = self.details_url.split('bibliocommons.com/item/show/')[1].gsub('052', '')
+        self.save
+      end
+    end
   end
 
   module ClassMethods

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,63 @@
+namespace :cleanup do
+
+  # Use it like this with one or more arguments: `rake cleanup:bib_records['book teacher_set']` or `rake cleanup:bib_records['book']`
+  desc "cleanup books or teacher sets"
+  task :bib_records, [:model_names] => :environment do |t, args|
+    args.model_names.split(' ').each do |model_name|
+      puts "Starting rake task to clean up #{model_name.humanize.pluralize}"
+      ActiveRecord::Base.transaction do
+        ids_with_duplicate_bibs = []
+        model_name.camelize.constantize.all.each do |record|
+          puts "#{model_name.humanize} ##{record.id}"
+          # if bnumber is present and it is found in other records, add that ID to the array
+          if record.bnumber.present? && model_name.camelize.constantize.where(bnumber: record.bnumber).count > 1
+            puts "#{model_name.humanize} ##{record.id} has a duplicate bnumber (#{record.bnumber})"
+            ids_with_duplicate_bibs << record.id
+          end
+        end
+        puts "IDs of #{model_name.humanize.downcase.pluralize} with duplicate bnumbers: #{ids_with_duplicate_bibs}"
+        puts "Duplicates count: #{ids_with_duplicate_bibs.size}"
+
+        # delete the duplicate holds and teacher sets, and move their holds & books over to the teacher set that was most recently created
+        ids_with_duplicate_bibs.each do |id_of_duplicate|
+          bnumber = model_name.camelize.constantize.find(id_of_duplicate).bnumber
+          duplicate_records = model_name.camelize.constantize.where(bnumber: bnumber).order('created_at DESC')
+          first_duplicate_record = duplicate_records[0]
+          duplicate_records.each do |duplicate_record|
+            # skip the first duplicate so that we do not delete it or shift its holds and other associated models
+            next if duplicate_record == first_duplicate_record
+            if model_name == 'teacher_set'
+              ['hold', 'subjects_teacher_set', 'teacher_set_book', 'teacher_set_note'].each do |associated_model_name|
+                associated_records_for_associated_model = associated_model_name.camelize.constantize.where(teacher_set_id: duplicate_record.id)
+                puts "There are #{associated_records_for_associated_model} associated #{associated_model_name}s to update."
+                associated_records_for_associated_model.each do |associated_record_for_associated_model|
+                  puts "Changing teacher_set_id for #{associated_model_name} ##{associated_record_for_associated_model.id}"
+                  associated_record_for_associated_model.update_attributes(teacher_set_id: first_duplicate_record.id)
+                end
+              end
+              # delete any duplicates in the join tables (this loop doesn't get triggered so there must be none)
+              while associated_model_name.camelize.constantize.where(teacher_set_id: first_duplicate_record.id).count > 1
+                associated_model_name.camelize.constantize.where(teacher_set_id: first_duplicate_record.id).first.destroy
+              end
+            elsif model_name == 'book'
+              ['teacher_set_book'].each do |associated_model_name|
+                associated_records_for_associated_model = associated_model_name.camelize.constantize.where(book_id: duplicate_record.id)
+                "There are #{associated_records_for_associated_model} associated #{associated_model_name}s to update."
+                associated_records_for_associated_model.each do |associated_record_for_associated_model|
+                  puts "Changing book_id for #{associated_model_name} ##{associated_record_for_associated_model.id}"
+                  associated_record_for_associated_model.update_attributes(book: first_duplicate_record)
+                end
+              end
+              # delete any duplicates in the join tables (this loop doesn't get triggered so there must be none)
+              while associated_model_name.camelize.constantize.where(teacher_set_id: first_duplicate_record.id).count > 1
+                associated_model_name.camelize.constantize.where(teacher_set_id: first_duplicate_record.id).first.destroy
+              end
+            end
+            puts "Deleting #{model_name.humanize.downcase} ##{duplicate_record.id}"
+            duplicate_record.destroy
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Add bnumber to books
2. Index books and teacher sets by bnumber
3. Enforce uniqueness on bnumber in the teacher set and book models and in the indexes
4. Create rake task to do the following:
- delete all duplicate books and teacher sets based on bnumbers (there are no teacher sets with duplicate bnumbers, FYI)
- change the book_id or teacher_set_id of the duplicate associated records (ie holds for teacher sets and teacher sets for books) to match the book or teacher set that wasn't deleted