### PR TITLE
Adding label for new/old to each changed attribute in a version

### DIFF
--- a/app/views/admin/_history.html.arb
+++ b/app/views/admin/_history.html.arb
@@ -99,7 +99,7 @@ panel "&nbsp;&nbsp;#{assigns[:versioned_object].class.name.humanize} History: #{
                 end
                 output += "BOOK<br>&bull; #{changed_book_action}: #{changed_book_title} (ID##{changed_book_id})<br><br>"
               elsif v[0].present? || v[1].present?
-                output += "#{k.upcase}<br>&bull; #{v[0]}<br>&bull; #{v[1]}<br><br>"
+                output += "#{k.upcase}<br>&bull; Old: #{v[0]}<br>&bull; New: #{v[1]}<br><br>"
               end
             end
             output.html_safe
@@ -138,7 +138,7 @@ panel "&nbsp;&nbsp;#{assigns[:versioned_object].class.name.humanize} History: #{
             end
             output += "BOOK<br>&bull; #{changed_book_action}: #{changed_book_title} (ID##{changed_book_id})<br><br>"
           elsif v[0].present? || v[1].present?
-            output += "#{k.upcase}<br>&bull; #{v[0]}<br>&bull; #{v[1]}<br><br>"
+            output += "#{k.upcase}<br>&bull; Old: #{v[0]}<br>&bull; New: #{v[1]}<br><br>"
           end
         end
         output.html_safe

--- a/app/views/admin/_version.html.erb
+++ b/app/views/admin/_version.html.erb
@@ -47,7 +47,7 @@
           <% changed_book_id = change_record.split('-')[1] %>
           <% changed_book_title = change_record.split('-')[2] %>
 
-          <%= change_action.upcase %> BOOK:<br>
+          <b><%= change_action.upcase %> BOOK:</b><br>
           <% if change_action == 'deleted' %>
             <%= changed_book_title %><br>
           <% else %>
@@ -55,9 +55,9 @@
           <% end %>
         <% else %>
           <% next if changeset[key][0].blank? && changeset[key][1].blank? # otherwise changing from nil to empty string will show %>
-          <%= key.titleize.upcase %>:<br>
-          <% changeset[key].each do |value| %>
-            &bull; <%= value.present? ? value : '(none)' %><br>
+          <b><%= key.titleize.upcase %>:</b><br>
+          <% changeset[key].each_with_index do |value, index| %>
+            &bull; <b><%= (index == 0 ? 'Old:' : 'New:') %></b> <%= value.present? ? value : '(none)' %><br>
           <% end %>
         <% end %>
         <br>


### PR DESCRIPTION
Look for "old/new" labels below.  Previously there were two bullet points and it wasn't clear which one was the old version of the attribute and which was the new.

# History Page: Before
![screen shot 2018-10-03 at 11 07 47 am](https://user-images.githubusercontent.com/1825103/46419902-e7558580-c6fc-11e8-95a1-25b0c9a72ae1.png)

# History Page: After
![screen shot 2018-10-03 at 11 07 37 am](https://user-images.githubusercontent.com/1825103/46419903-e7558580-c6fc-11e8-9408-945cc85a3563.png)

# Version Sidebar: Before
![screen shot 2018-10-03 at 11 07 13 am](https://user-images.githubusercontent.com/1825103/46419904-e7558580-c6fc-11e8-8cc9-516d591fdea5.png)

# Version Sidebar: After
![screen shot 2018-10-03 at 11 06 58 am](https://user-images.githubusercontent.com/1825103/46419905-e7558580-c6fc-11e8-8472-25b26b929771.png)
