### PR TITLE
Create and update teacher set records MLN-300, 302, 328

### DIFF
--- a/app/controllers/api/v1/bibs_controller.rb
+++ b/app/controllers/api/v1/bibs_controller.rb
@@ -1,31 +1,99 @@
 class Api::V1::BibsController < ApplicationController
+  include LogWrapper
+  before_filter :set_request_body
+
+  # Receive teacher sets from a POST request.
+  # All records are inside @request_body.
+  # Find or create a teacher set in the MLN db and its associated books.
   def create_or_update_teacher_sets
-    render status: 200, json: {
-      teacher_sets: [
-        {
-          id: 1,
-          title: 'Example title 1'
-        },
-        {
-          id: 2,
-          title: 'Example title 2'
-        }
-      ]
-    }.to_json
+    error_code_and_message = validate_request
+    if error_code_and_message.any?
+      render_error(error_code_and_message)
+      return
+    end
+
+    saved_teacher_sets = []
+    @request_body.each do |teacher_set_record|
+      teacher_set = TeacherSet.where(bnumber: "b#{teacher_set_record['id']}").first_or_initialize
+      teacher_set.update_attributes(
+        title: teacher_set_record[:title]
+        # TODO: update more teacher_set attributes here once the API contract is complete
+      )
+      teacher_set.update_included_book_list(teacher_set_record)
+      if teacher_set.save
+        saved_teacher_sets << teacher_set
+      else
+        # notify_admin_failed_teacherset(teacher_set)
+      end
+    end
+
+    render status: 200, json: { teacher_sets: saved_teacher_sets_json_array(saved_teacher_sets) }.to_json
   end
 
   def delete_teacher_sets
-    render status: 200, json: {
-      teacher_sets: [
-        {
-          id: 1,
-          title: 'Example title 1'
-        },
-        {
-          id: 2,
-          title: 'Example title 2'
-        }
-      ]
+    error_code_and_message = validate_request
+    if error_code_and_message.any?
+      render_error(error_code_and_message)
+      return
+    end
+
+    saved_teacher_sets = []
+    @request_body.each do |teacher_set_record|
+      teacher_set = TeacherSet.where(bnumber: "b#{teacher_set_record['id']}").first
+      if teacher_set
+        saved_teacher_sets << teacher_set
+        teacher_set.destroy
+      end
+    end
+
+    render status: 200, json: { teacher_sets: saved_teacher_sets_json_array(saved_teacher_sets) }.to_json
+  end
+
+  private
+
+  # build saved_teacher_sets_json_array for the response body
+  def saved_teacher_sets_json_array(saved_teacher_sets)
+    return [] if saved_teacher_sets.empty?
+    saved_teacher_sets_json_array = []
+    saved_teacher_sets.each do |saved_ts|
+      saved_teacher_sets_json_array << { id: saved_ts.id, bnumber: saved_ts.bnumber, title: saved_ts.title }
+    end
+    saved_teacher_sets_json_array
+  end
+
+  # this validates that the request is in the correct format
+  def validate_request
+    if !@request_body.present?
+      return [400, 'request body is missing']
+    end
+    # the tests send data in as params[:_json] but Postman sends it in as an StringIO object
+    @request_body.each do |teacher_set_json|
+      if teacher_set_json['id'].blank?
+        return [400, "ID is missing in teacher_set_json: #{teacher_set_json}"]
+      end
+    end
+    if action_name == 'create_or_update_teacher_sets'
+      # specific methods can go here
+    elsif action_name == 'delete_teacher_sets'
+      # specific methods can go here
+    end
+    return []
+  end
+
+  def render_error(error_code_and_message)
+    LogWrapper.log('ERROR', {
+      'message' => error_code_and_message[1],
+      'method' => "#{controller_name}##{action_name}",
+      'status' => error_code_and_message[0]
+    })
+    render status: error_code_and_message[0], json: {
+      message: error_code_and_message[1]
     }.to_json
+  end
+
+  def set_request_body
+    # binding.pry
+    # request_body = request.body.read
+    @request_body = params[:_json] || JSON.parse(request_body)
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -144,4 +144,8 @@ class Book < ActiveRecord::Base
       teacher_set.update_attributes(last_book_change: "updated-#{self.id}-#{self.title}")
     end
   end
+
+  def update_from_isbn
+    # later we will call the BibService to get more fields for this new book
+  end
 end

--- a/lib/log_wrapper.rb
+++ b/lib/log_wrapper.rb
@@ -1,29 +1,26 @@
-module LogWrapper 
+module LogWrapper
 
-	# Wrapper module server's as a wrapper to 
-	# add output to the log file. 
+	# Wrapper module server's as a wrapper to
+	# add output to the log file.
 	# The method log take's in 2 parameters.
 	# A string passed in as level and a hash
-	# passed in as message. Please look at 
-	# examples from the user.rb model. 
+	# passed in as message. Please look at
+	# examples from the user.rb model.
 
-	def self.log(level,message)
+	def self.log(level, message)
+		severity_levels = {
+			'DEBUG' => 0,
+			'INFO' => 1,
+			'WARN' => 2,
+			'ERROR' => 3,
+			'FATAL' => 4,
+			'UNKNOWN' => 5
+		}
 
-	severity_levels = 
-	    {
-		'DEBUG' => 0,
-		'INFO' => 1,
-		'WARN' => 2,
-		'ERROR' => 3,
-		'FATAL' => 4,
-		'UNKNOWN' => 5 
-	   }
+		message['timestamp'] = Time.now.strftime("%Y-%m-%dT%H:%M:%S.%L%z")
+		message['level'] = level
 
-	message['timestamp'] = Time.now.strftime("%Y-%m-%dT%H:%M:%S.%L%z")
-	message['level'] = level
+		Rails.logger.add(severity_levels[level], message.to_json)
+	end
 
-	Rails.logger.add(severity_levels['level'],message.to_json)
-
-	end 
-
-end 
+end

--- a/test/functional/api/v1/bibs_controller_test.rb
+++ b/test/functional/api/v1/bibs_controller_test.rb
@@ -1,17 +1,1351 @@
 require 'test_helper'
 
+BNUMBER1 = "998"
+BNUMBER2 = "999"
+
+TWO_TEACHER_SETS_WITH_10_ISBNS_EACH = [
+  {
+    "id": "#{BNUMBER1}",
+    "nyplSource": "sierra-nypl",
+    "nyplType": "bib",
+    "updatedDate": "2017-08-23T20:22:13-04:00",
+    "createdDate": "2017-08-23T14:46:46-04:00",
+    "deletedDate": nil,
+    "deleted": false,
+    "locations": [
+      {
+        "code": "ed",
+        "name": "LSC Educator Collection"
+      }
+    ],
+    "suppressed": false,
+    "lang": {
+      "code": "eng",
+      "name": "English"
+    },
+    "title": "Books for Reading and Sharing - Elementary School!",
+    "author": "",
+    "materialType": {
+      "code": "8",
+      "value": "TEACHER SET"
+    },
+    "bibLevel": {
+      "code": "m",
+      "value": "MONOGRAPH"
+    },
+    "publishYear": nil,
+    "catalogDate": "2017-08-23",
+    "country": {
+      "code": "xx ",
+      "name": "Unknown or undetermined"
+    },
+    "normTitle": "books for reading and sharing elementary school",
+    "normAuthor": "",
+    "standardNumbers": [],
+    "controlNumber": "",
+    "fixedFields": {
+      "24": {
+        "label": "Language",
+        "value": "eng",
+        "display": "English"
+      },
+      "25": {
+        "label": "Skip",
+        "value": "0",
+        "display": nil
+      },
+      "26": {
+        "label": "Location",
+        "value": "ed   ",
+        "display": "LSC Educator Collection"
+      },
+      "27": {
+        "label": "COPIES",
+        "value": "0",
+        "display": nil
+      },
+      "28": {
+        "label": "Cat. Date",
+        "value": "2017-08-23",
+        "display": nil
+      },
+      "29": {
+        "label": "Bib Level",
+        "value": "m",
+        "display": "MONOGRAPH"
+      },
+      "30": {
+        "label": "Material Type",
+        "value": "8",
+        "display": "TEACHER SET"
+      },
+      "31": {
+        "label": "Bib Code 3",
+        "value": "-",
+        "display": nil
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "b",
+        "display": nil
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "21323534",
+        "display": nil
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2017-08-23T14:46:46Z",
+        "display": nil
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2017-08-23T20:22:13Z",
+        "display": nil
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "2",
+        "display": nil
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": nil
+      },
+      "89": {
+        "label": "Country",
+        "value": "xx ",
+        "display": "Unknown or undetermined"
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2017-08-23T20:20:00Z",
+        "display": nil
+      },
+      "107": {
+        "label": "MARC Type",
+        "value": " ",
+        "display": nil
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "c",
+        "marcTag": "091",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Teacher Set ELA A Books 4"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Picture books for children."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "690",
+        "ind1": "0",
+        "ind2": "7",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "English Language Arts."
+          },
+          {
+            "tag": "2",
+            "content": "local"
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "2 copies of 10 titles."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Anna carries water -- Monkey & Robot -- Mother Bruce -- The book with no pictures -- The day the crayons quit -- The scraps book : notes from a colorful life -- Three bears in a boat -- Blizzard -- Bright Sky, Starry City -- Hula-Hoopin Queen."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "520",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Topic Set (20 books) - This set of titles are great for reading aloud and sharing in the classroom - grades 1 and grades 2.  These titles were former selections from the NYC Department of Education NYC Reads 365 list."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "521",
+        "ind1": "2",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "1-2."
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "300",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "20 v."
+          }
+        ]
+      },
+      {
+        "fieldTag": "s",
+        "marcTag": "490",
+        "ind1": "0",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Teacher Sets: MyLibraryNYC Program"
+          }
+        ]
+      },
+      {
+        "fieldTag": "t",
+        "marcTag": "245",
+        "ind1": "0",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Books for Reading and Sharing - Elementary School!"
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "246",
+        "ind1": "3",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "English Language Arts: Books for Reading and Sharing - Elementary School! Gr. 1-2 (Teacher Set)."
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "901",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "ed"
+          },
+          {
+            "tag": "b",
+            "content": "SEL"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "944",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "9781896580609  9781442429789  9781484730881  9780803741713  9780399255373  9781442435711 9780803739932  9781423178651  9781554984053  9781600608469"
+          }
+        ]
+      },
+      {
+        "fieldTag": "_",
+        "marcTag": nil,
+        "ind1": nil,
+        "ind2": nil,
+        "content": "00000nam  2200000 a 4500",
+        "subfields": nil
+      }
+    ]
+  },
+  {
+    "id": "#{BNUMBER2}",
+    "nyplSource": "sierra-nypl",
+    "nyplType": "bib",
+    "updatedDate": "2017-08-23T20:22:13-04:00",
+    "createdDate": "2017-08-23T14:46:46-04:00",
+    "deletedDate": nil,
+    "deleted": false,
+    "locations": [
+      {
+        "code": "ed",
+        "name": "LSC Educator Collection"
+      }
+    ],
+    "suppressed": false,
+    "lang": {
+      "code": "eng",
+      "name": "English"
+    },
+    "title": "Title 2",
+    "author": "",
+    "materialType": {
+      "code": "8",
+      "value": "TEACHER SET"
+    },
+    "bibLevel": {
+      "code": "m",
+      "value": "MONOGRAPH"
+    },
+    "publishYear": nil,
+    "catalogDate": "2017-08-23",
+    "country": {
+      "code": "xx ",
+      "name": "Unknown or undetermined"
+    },
+    "normTitle": "books for reading and sharing elementary school",
+    "normAuthor": "",
+    "standardNumbers": [],
+    "controlNumber": "",
+    "fixedFields": {
+      "24": {
+        "label": "Language",
+        "value": "eng",
+        "display": "English"
+      },
+      "25": {
+        "label": "Skip",
+        "value": "0",
+        "display": nil
+      },
+      "26": {
+        "label": "Location",
+        "value": "ed   ",
+        "display": "LSC Educator Collection"
+      },
+      "27": {
+        "label": "COPIES",
+        "value": "0",
+        "display": nil
+      },
+      "28": {
+        "label": "Cat. Date",
+        "value": "2017-08-23",
+        "display": nil
+      },
+      "29": {
+        "label": "Bib Level",
+        "value": "m",
+        "display": "MONOGRAPH"
+      },
+      "30": {
+        "label": "Material Type",
+        "value": "8",
+        "display": "TEACHER SET"
+      },
+      "31": {
+        "label": "Bib Code 3",
+        "value": "-",
+        "display": nil
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "b",
+        "display": nil
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "21323534",
+        "display": nil
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2017-08-23T14:46:46Z",
+        "display": nil
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2017-08-23T20:22:13Z",
+        "display": nil
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "2",
+        "display": nil
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": nil
+      },
+      "89": {
+        "label": "Country",
+        "value": "xx ",
+        "display": "Unknown or undetermined"
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2017-08-23T20:20:00Z",
+        "display": nil
+      },
+      "107": {
+        "label": "MARC Type",
+        "value": " ",
+        "display": nil
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "c",
+        "marcTag": "091",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Teacher Set ELA A Books 4"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Picture books for children."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "690",
+        "ind1": "0",
+        "ind2": "7",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "English Language Arts."
+          },
+          {
+            "tag": "2",
+            "content": "local"
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "2 copies of 10 titles."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Anna carries water -- Monkey & Robot -- Mother Bruce -- The book with no pictures -- The day the crayons quit -- The scraps book : notes from a colorful life -- Three bears in a boat -- Blizzard -- Bright Sky, Starry City -- Hula-Hoopin Queen."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "520",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Topic Set (20 books) - This set of titles are great for reading aloud and sharing in the classroom - grades 1 and grades 2.  These titles were former selections from the NYC Department of Education NYC Reads 365 list."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "521",
+        "ind1": "2",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "1-2."
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "300",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "20 v."
+          }
+        ]
+      },
+      {
+        "fieldTag": "s",
+        "marcTag": "490",
+        "ind1": "0",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Teacher Sets: MyLibraryNYC Program"
+          }
+        ]
+      },
+      {
+        "fieldTag": "t",
+        "marcTag": "245",
+        "ind1": "0",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Books for Reading and Sharing - Elementary School!"
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "246",
+        "ind1": "3",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "English Language Arts: Books for Reading and Sharing - Elementary School! Gr. 1-2 (Teacher Set)."
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "901",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "ed"
+          },
+          {
+            "tag": "b",
+            "content": "SEL"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "944",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "9781896580609  9781442429789  9781484730881  9780803741713  9780399255373  9781442435711 9780803739932  9781423178651  9781554984053  9781600608469"
+          }
+        ]
+      },
+      {
+        "fieldTag": "_",
+        "marcTag": nil,
+        "ind1": nil,
+        "ind2": nil,
+        "content": "00000nam  2200000 a 4500",
+        "subfields": nil
+      }
+    ]
+  }
+]
+
+TWO_TEACHER_SETS_WITH_3_ISBNS_EACH = [
+  {
+    "id": "#{BNUMBER1}",
+    "nyplSource": "sierra-nypl",
+    "nyplType": "bib",
+    "updatedDate": "2017-08-23T20:22:13-04:00",
+    "createdDate": "2017-08-23T14:46:46-04:00",
+    "deletedDate": nil,
+    "deleted": false,
+    "locations": [
+      {
+        "code": "ed",
+        "name": "LSC Educator Collection"
+      }
+    ],
+    "suppressed": false,
+    "lang": {
+      "code": "eng",
+      "name": "English"
+    },
+    "title": "Books for Reading and Sharing - Elementary School!",
+    "author": "",
+    "materialType": {
+      "code": "8",
+      "value": "TEACHER SET"
+    },
+    "bibLevel": {
+      "code": "m",
+      "value": "MONOGRAPH"
+    },
+    "publishYear": nil,
+    "catalogDate": "2017-08-23",
+    "country": {
+      "code": "xx ",
+      "name": "Unknown or undetermined"
+    },
+    "normTitle": "books for reading and sharing elementary school",
+    "normAuthor": "",
+    "standardNumbers": [],
+    "controlNumber": "",
+    "fixedFields": {
+      "24": {
+        "label": "Language",
+        "value": "eng",
+        "display": "English"
+      },
+      "25": {
+        "label": "Skip",
+        "value": "0",
+        "display": nil
+      },
+      "26": {
+        "label": "Location",
+        "value": "ed   ",
+        "display": "LSC Educator Collection"
+      },
+      "27": {
+        "label": "COPIES",
+        "value": "0",
+        "display": nil
+      },
+      "28": {
+        "label": "Cat. Date",
+        "value": "2017-08-23",
+        "display": nil
+      },
+      "29": {
+        "label": "Bib Level",
+        "value": "m",
+        "display": "MONOGRAPH"
+      },
+      "30": {
+        "label": "Material Type",
+        "value": "8",
+        "display": "TEACHER SET"
+      },
+      "31": {
+        "label": "Bib Code 3",
+        "value": "-",
+        "display": nil
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "b",
+        "display": nil
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "21323534",
+        "display": nil
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2017-08-23T14:46:46Z",
+        "display": nil
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2017-08-23T20:22:13Z",
+        "display": nil
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "2",
+        "display": nil
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": nil
+      },
+      "89": {
+        "label": "Country",
+        "value": "xx ",
+        "display": "Unknown or undetermined"
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2017-08-23T20:20:00Z",
+        "display": nil
+      },
+      "107": {
+        "label": "MARC Type",
+        "value": " ",
+        "display": nil
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "c",
+        "marcTag": "091",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Teacher Set ELA A Books 4"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Picture books for children."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "690",
+        "ind1": "0",
+        "ind2": "7",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "English Language Arts."
+          },
+          {
+            "tag": "2",
+            "content": "local"
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "2 copies of 10 titles."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Anna carries water -- Monkey & Robot -- Mother Bruce -- The book with no pictures -- The day the crayons quit -- The scraps book : notes from a colorful life -- Three bears in a boat -- Blizzard -- Bright Sky, Starry City -- Hula-Hoopin Queen."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "520",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Topic Set (20 books) - This set of titles are great for reading aloud and sharing in the classroom - grades 1 and grades 2.  These titles were former selections from the NYC Department of Education NYC Reads 365 list."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "521",
+        "ind1": "2",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "1-2."
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "300",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "20 v."
+          }
+        ]
+      },
+      {
+        "fieldTag": "s",
+        "marcTag": "490",
+        "ind1": "0",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Teacher Sets: MyLibraryNYC Program"
+          }
+        ]
+      },
+      {
+        "fieldTag": "t",
+        "marcTag": "245",
+        "ind1": "0",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Books for Reading and Sharing - Elementary School!"
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "246",
+        "ind1": "3",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "English Language Arts: Books for Reading and Sharing - Elementary School! Gr. 1-2 (Teacher Set)."
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "901",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "ed"
+          },
+          {
+            "tag": "b",
+            "content": "SEL"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "944",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "9781896580609  9781442429789  9781484730881"
+          }
+        ]
+      },
+      {
+        "fieldTag": "_",
+        "marcTag": nil,
+        "ind1": nil,
+        "ind2": nil,
+        "content": "00000nam  2200000 a 4500",
+        "subfields": nil
+      }
+    ]
+  },
+  {
+    "id": "#{BNUMBER2}",
+    "nyplSource": "sierra-nypl",
+    "nyplType": "bib",
+    "updatedDate": "2017-08-23T20:22:13-04:00",
+    "createdDate": "2017-08-23T14:46:46-04:00",
+    "deletedDate": nil,
+    "deleted": false,
+    "locations": [
+      {
+        "code": "ed",
+        "name": "LSC Educator Collection"
+      }
+    ],
+    "suppressed": false,
+    "lang": {
+      "code": "eng",
+      "name": "English"
+    },
+    "title": "Title 2",
+    "author": "",
+    "materialType": {
+      "code": "8",
+      "value": "TEACHER SET"
+    },
+    "bibLevel": {
+      "code": "m",
+      "value": "MONOGRAPH"
+    },
+    "publishYear": nil,
+    "catalogDate": "2017-08-23",
+    "country": {
+      "code": "xx ",
+      "name": "Unknown or undetermined"
+    },
+    "normTitle": "books for reading and sharing elementary school",
+    "normAuthor": "",
+    "standardNumbers": [],
+    "controlNumber": "",
+    "fixedFields": {
+      "24": {
+        "label": "Language",
+        "value": "eng",
+        "display": "English"
+      },
+      "25": {
+        "label": "Skip",
+        "value": "0",
+        "display": nil
+      },
+      "26": {
+        "label": "Location",
+        "value": "ed   ",
+        "display": "LSC Educator Collection"
+      },
+      "27": {
+        "label": "COPIES",
+        "value": "0",
+        "display": nil
+      },
+      "28": {
+        "label": "Cat. Date",
+        "value": "2017-08-23",
+        "display": nil
+      },
+      "29": {
+        "label": "Bib Level",
+        "value": "m",
+        "display": "MONOGRAPH"
+      },
+      "30": {
+        "label": "Material Type",
+        "value": "8",
+        "display": "TEACHER SET"
+      },
+      "31": {
+        "label": "Bib Code 3",
+        "value": "-",
+        "display": nil
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "b",
+        "display": nil
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "21323534",
+        "display": nil
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2017-08-23T14:46:46Z",
+        "display": nil
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2017-08-23T20:22:13Z",
+        "display": nil
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "2",
+        "display": nil
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": nil
+      },
+      "89": {
+        "label": "Country",
+        "value": "xx ",
+        "display": "Unknown or undetermined"
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2017-08-23T20:20:00Z",
+        "display": nil
+      },
+      "107": {
+        "label": "MARC Type",
+        "value": " ",
+        "display": nil
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "c",
+        "marcTag": "091",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Teacher Set ELA A Books 4"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Picture books for children."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "690",
+        "ind1": "0",
+        "ind2": "7",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "English Language Arts."
+          },
+          {
+            "tag": "2",
+            "content": "local"
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "2 copies of 10 titles."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Anna carries water -- Monkey & Robot -- Mother Bruce -- The book with no pictures -- The day the crayons quit -- The scraps book : notes from a colorful life -- Three bears in a boat -- Blizzard -- Bright Sky, Starry City -- Hula-Hoopin Queen."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "520",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Topic Set (20 books) - This set of titles are great for reading aloud and sharing in the classroom - grades 1 and grades 2.  These titles were former selections from the NYC Department of Education NYC Reads 365 list."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "521",
+        "ind1": "2",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "1-2."
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "300",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "20 v."
+          }
+        ]
+      },
+      {
+        "fieldTag": "s",
+        "marcTag": "490",
+        "ind1": "0",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Teacher Sets: MyLibraryNYC Program"
+          }
+        ]
+      },
+      {
+        "fieldTag": "t",
+        "marcTag": "245",
+        "ind1": "0",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Books for Reading and Sharing - Elementary School!"
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "246",
+        "ind1": "3",
+        "ind2": "0",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "English Language Arts: Books for Reading and Sharing - Elementary School! Gr. 1-2 (Teacher Set)."
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "901",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "ed"
+          },
+          {
+            "tag": "b",
+            "content": "SEL"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "944",
+        "ind1": " ",
+        "ind2": " ",
+        "content": nil,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "9781896580609  9781442429789  9781484730881"
+          }
+        ]
+      },
+      {
+        "fieldTag": "_",
+        "marcTag": nil,
+        "ind1": nil,
+        "ind2": nil,
+        "content": "00000nam  2200000 a 4500",
+        "subfields": nil
+      }
+    ]
+  }
+]
+
+TWO_TEACHER_SETS_TO_DELETE = [{
+    "id": "0",
+    "title": "Example for non-existant bnumber"
+  },
+  {
+      "id": "#{BNUMBER1}",
+      "nyplSource": "sierra-nypl",
+      "nyplType": "bib",
+      "updatedDate": "2017-08-25T06:32:01-04:00",
+      "createdDate": nil,
+      "deletedDate": "2012-06-08",
+      "deleted": true,
+      "locations": [],
+      "suppressed": nil,
+      "lang": nil,
+      "title": nil,
+      "author": nil,
+      "materialType": nil,
+      "bibLevel": nil,
+      "publishYear": nil,
+      "catalogDate": nil,
+      "country": nil,
+      "normTitle": nil,
+      "normAuthor": nil,
+      "standardNumbers": [],
+      "controlNumber": "",
+      "fixedFields": {},
+      "varFields": [],
+      "count": 1,
+      "totalCount": 0,
+      "statusCode": 200,
+      "debugInfo": []
+    }
+]
+
 class Api::BibsControllerTest < ActionController::TestCase
   def setup
     @controller = Api::V1::BibsController.new
   end
 
-  test "should create or update teacher sets when given a bib number" do
-    post 'create_or_update_teacher_sets'
+  # test 'respond with 400 if request body is missing' do
+  #   post 'create_or_update_teacher_sets'
+  #   assert response.status == 400
+  # end
+
+  test "respond with 400 if ID isn't present for at least one JSON record" do
+    post 'create_or_update_teacher_sets', { _json: [{ not_an_id: 0 }] }
+    assert response.status == 400
+  end
+
+  test "should create or update teacher sets when given a ID (a.k.a. bnumber)" do
+    post 'create_or_update_teacher_sets', { _json: [{ id: BNUMBER1, another_field: 'x' }, { id: BNUMBER2, another_field: 'x' }] }
     assert_response :success
+    assert JSON.parse(response.body)['teacher_sets'].map{ |x| x['bnumber'] } == ["b#{BNUMBER1}", "b#{BNUMBER2}"]
+  end
+
+  test "should create create associated books" do
+    assert Book.count == 0
+    assert TeacherSet.count == 0
+    post 'create_or_update_teacher_sets', { _json: TWO_TEACHER_SETS_WITH_10_ISBNS_EACH }
+    assert_response :success
+    assert Book.count == 10
+    assert TeacherSet.count == 2
+    assert TeacherSet.first.books.count == 10 # both teacher sets have the same books
+    assert TeacherSetBook.count == 20 # both teacher sets have the same books
+    assert JSON.parse(response.body)['teacher_sets'].map{ |x| x['bnumber'] } == ["b#{BNUMBER1}", "b#{BNUMBER2}"]
+
+    # simulate an update which removes some books from each teacher_set
+    post 'create_or_update_teacher_sets', { _json: TWO_TEACHER_SETS_WITH_3_ISBNS_EACH }
+    assert_response :success
+    assert Book.count == 10 # no change
+    assert TeacherSet.count == 2 # no change
+    assert TeacherSet.first.books.count == 3 # both teacher sets have the same books
+    assert TeacherSetBook.count == 6 # some records are deleted in the join table
+    assert JSON.parse(response.body)['teacher_sets'].map{ |x| x['bnumber'] } == ["b#{BNUMBER1}", "b#{BNUMBER2}"]
   end
 
   test "should delete teacher sets when given a bib number" do
-    delete 'delete_teacher_sets'
+    TeacherSet.where(bnumber: "b#{BNUMBER1}").first_or_create
+    delete 'delete_teacher_sets', { _json: TWO_TEACHER_SETS_TO_DELETE }
     assert_response :success
+    assert JSON.parse(response.body)['teacher_sets'].map{ |x| x['bnumber'] } == ["b#{BNUMBER1}"]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,7 +54,7 @@ class ActiveSupport::TestCase
     stub_request(:get, 'https://dev-platform.nypl.org/api/v0.1/patrons?email=' +
     email)
       .to_return(status: 200, body: {
-        'statusCode' => 404,
+        'status' => 404,
         'type' => 'exception',
         'message' => 'No matching record found',
         'error' => [],

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -89,7 +89,7 @@ class UserTest < ActiveSupport::TestCase
         mock_check_email_request(new_email)
         response = @user.get_email_records(new_email)
         expected_response = {
-          'statusCode' => 404,
+          'status' => 404,
           'type' => 'exception',
           'message' => 'No matching record found',
           'error' => [],


### PR DESCRIPTION
This PR is for accepting JSON related to teacher sets and books.  We use the `bnumber` to look up the teacher set.  If it exists, we update it; if it doesn't exist, we create it.

We also loop through the ISBNs and create associations to those books through the `TeacherSetBook` table.  If the book doesn't exist, we create it.  We also remove teacher_set_books records for books with an ISBN that is not in the teacher_set's list of ISBNs