### PR TITLE
Fix set_request_body method in bibs_controller

### DIFF
--- a/app/controllers/api/v1/bibs_controller.rb
+++ b/app/controllers/api/v1/bibs_controller.rb
@@ -92,8 +92,6 @@ class Api::V1::BibsController < ApplicationController
   end
 
   def set_request_body
-    # binding.pry
-    # request_body = request.body.read
-    @request_body = params[:_json] || JSON.parse(request_body)
+    @request_body = params[:_json] || JSON.parse(request.body.read)
   end
 end


### PR DESCRIPTION
Tests were passing because they access the parameters differently.  This fixes a bug I noticed when testing the method with Postman.