### PR TITLE
Provide teacher set unavailable flag in admin MLN-350

### DIFF
--- a/app/admin/teacher_sets.rb
+++ b/app/admin/teacher_sets.rb
@@ -1,4 +1,9 @@
 ActiveAdmin.register TeacherSet do
+  # The line below was causing an error on the teacher set index page.
+  # Even after we remove it, we can still search by teacher sets, so it should be removed.
+  # All default filters remain in the sidebar when you use this syntax to remove one filter.
+  remove_filter :subject_teacher_sets
+
   actions :show, :index
 
   menu :priority => 3
@@ -17,7 +22,9 @@ ActiveAdmin.register TeacherSet do
     column :title do |teacher_set|
       link_to(teacher_set.title, admin_teacher_set_path(teacher_set))
     end
-    column :availability
+    column('Available', :admin_availability, sortable: :admin_availability) do |teacher_set|
+      render(partial: 'teacher_sets/availability_links_container', locals: { teacher_set: teacher_set, action: 'index' })
+    end
     column :created_at
     column :updated_at
   end
@@ -27,6 +34,32 @@ ActiveAdmin.register TeacherSet do
     @versioned_object = TeacherSet.find(params[:id])
     @versions = PaperTrail::Version.where(item_type: 'TeacherSet', item_id: @versioned_object.id).order('created_at ASC')
     render partial: 'admin/history'
+  end
+
+  action_item only: :show do
+    render(partial: 'teacher_sets/availability_links_container', locals: { teacher_set: teacher_set, action: 'show' })
+  end
+
+  member_action :make_available, method: :put do
+    teacher_set = TeacherSet.find(params[:id])
+    teacher_set.admin_availability = true
+    teacher_set.save
+    if request.format == :html
+      redirect_to admin_teacher_set_path(teacher_set)
+    else
+      render js: "makeAvailableTeacherSet(#{teacher_set.id}, true);"
+    end
+  end
+
+  member_action :make_unavailable, method: :put do
+    teacher_set = TeacherSet.find(params[:id])
+    teacher_set.admin_availability = false
+    teacher_set.save
+    if request.format == :html
+      redirect_to admin_teacher_set_path(teacher_set)
+    else
+      render js: "makeAvailableTeacherSet(#{teacher_set.id}, false);"
+    end
   end
 
   form do |f|
@@ -108,7 +141,9 @@ ActiveAdmin.register TeacherSet do
       teacher_set_version = teacher_set
     end
 
-    h2 "Availability: #{teacher_set.availability}"
+    # Availability on the line below was based on item availability and set by the scraper.
+    # Now that the scraper is turned off, we use admin_availability, set in the admin dashboard.
+    # h2 "Availability: #{teacher_set.availability}"
     attributes_table do
       row 'Biblio page' do link_to(teacher_set_version.details_url, teacher_set_version.details_url, target:'_blank') end
       row 'Call Number' do teacher_set_version.call_number end

--- a/app/assets/javascripts/active_admin_custom.js
+++ b/app/assets/javascripts/active_admin_custom.js
@@ -119,3 +119,13 @@ function activateSchool(schoolId, activate) {
     $('#activate-school-' + schoolId + '-container').show();
   }
 };
+
+function makeAvailableTeacherSet(teacherSetId, make_available) {
+  if (make_available == true){
+    $('#make-available-teacher-set-' + teacherSetId + '-container').hide();
+    $('#make-unavailable-teacher-set-' + teacherSetId + '-container').show();
+  } else {
+    $('#make-unavailable-teacher-set-' + teacherSetId + '-container').hide();
+    $('#make-available-teacher-set-' + teacherSetId + '-container').show();
+  }
+};

--- a/app/models/teacher_set.rb
+++ b/app/models/teacher_set.rb
@@ -732,4 +732,9 @@ class TeacherSet < ActiveRecord::Base
       TeacherSetNote.create(teacher_set_id: self.id, content: note_content)
     end
   end
+
+  # Override availability (set by scraper) with admin_availability (set in admin dashboard)
+  def availability
+    return self.admin_availability
+  end
 end

--- a/app/views/teacher_sets/_availability_links_container.html.erb
+++ b/app/views/teacher_sets/_availability_links_container.html.erb
@@ -1,0 +1,14 @@
+<div id="make-available-teacher-set-<%= teacher_set.id %>-container"
+     style="<%= !teacher_set.admin_availability? ? '' : 'display:none;' %> <%= (action == 'index' ? 'margin-left:20px;' : '') %>">
+  <a href="<%= make_available_admin_teacher_set_path(teacher_set) %>" data-method="put" data-remote="true">
+    <%= image_tag('unchecked.png', height: 20, width: 20, alt: '') %>
+    <%= (action == 'show' ? "<span style='position:relative; top:-5px; right:-3px'>Unavailable</span>" : '').html_safe %>
+  </a>
+</div>
+<div id="make-unavailable-teacher-set-<%= teacher_set.id %>-container"
+     style="<%= teacher_set.admin_availability? ? '' : 'display:none;' %> <%= (action == 'index' ? 'margin-left:20px;' : '') %>">
+  <a href="<%= make_unavailable_admin_teacher_set_path(teacher_set) %>" data-method="put" data-remote="true">
+    <%= image_tag('checked.png', height: 20, width: 20, alt: '') %>
+    <%= (action == 'show' ? "<span style='position:relative; top:-5px; right:-3px'>Available</span>" : '').html_safe %>
+  </a>
+</div>

--- a/db/migrate/20181018221847_add_admin_availability_to_teacher_sets.rb
+++ b/db/migrate/20181018221847_add_admin_availability_to_teacher_sets.rb
@@ -1,0 +1,5 @@
+class AddAdminAvailabilityToTeacherSets < ActiveRecord::Migration
+  def change
+    add_column :teacher_sets, :admin_availability, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20181015105316) do
+ActiveRecord::Schema.define(:version => 20181018221847) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -193,6 +193,7 @@ ActiveRecord::Schema.define(:version => 20181015105316) do
     t.string   "set_type",                    :limit => 20
     t.text     "contents"
     t.string   "last_book_change"
+    t.boolean  "admin_availability",                        :default => true
   end
 
   add_index "teacher_sets", ["availability"], :name => "index_teacher_sets_availaibilty"


### PR DESCRIPTION
# Show Page
On the teacher-set-show page, there is a button in the top-right to change a set from available to unavailable.
<img width="1099" alt="screen shot 2018-10-22 at 9 47 22 am" src="https://user-images.githubusercontent.com/1825103/47296552-968cca80-d5e0-11e8-8f80-d8c7ebdafc02.png">

# Index Page
On the teacher-set-show page, there is a column with a checkbox for changing availability of any set.  This is particularly useful when using the filters on the right and changing availability of many teacher sets with just one click each.
<img width="1079" alt="screen shot 2018-10-22 at 9 47 08 am" src="https://user-images.githubusercontent.com/1825103/47296553-968cca80-d5e0-11e8-8794-67e27b67c923.png">
