### PR TITLE
Make total_copies and available_copies editable

### DIFF
--- a/app/admin/teacher_sets.rb
+++ b/app/admin/teacher_sets.rb
@@ -66,19 +66,6 @@ ActiveAdmin.register TeacherSet do
     end
   end
 
-  form do |f|
-    f.semantic_errors *f.object.errors.keys
-    f.inputs "Details" do
-      f.input :title
-    end
-    f.inputs "Description" do
-      f.input :description, :input_html => { :rows=> 3 }
-    end
-    f.inputs "Call Number" do
-      f.input :call_number
-    end
-  end
-
   member_action :make_unavailable, method: :put do
     teacher_set = TeacherSet.find(params[:id])
     teacher_set.admin_availability = false

--- a/app/admin/teacher_sets.rb
+++ b/app/admin/teacher_sets.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register TeacherSet do
   # All default filters remain in the sidebar when you use this syntax to remove one filter.
   remove_filter :subject_teacher_sets
 
-  actions :show, :index
+  actions :index, :show, :edit, :update
 
   menu :priority => 3
   sidebar :versions, :partial => "admin/version", :only => :show
@@ -36,8 +36,12 @@ ActiveAdmin.register TeacherSet do
     render partial: 'admin/history'
   end
 
-  action_item only: :show do
+  action_item only: [:show] do
     render(partial: 'teacher_sets/availability_links_container', locals: { teacher_set: teacher_set, action: 'show' })
+  end
+
+  action_item only: [:show] do
+    render(partial: 'teacher_sets/edit_button_container', locals: { teacher_set: teacher_set })
   end
 
   member_action :make_available, method: :put do
@@ -73,47 +77,25 @@ ActiveAdmin.register TeacherSet do
     f.inputs "Call Number" do
       f.input :call_number
     end
+  end
+
+  member_action :make_unavailable, method: :put do
+    teacher_set = TeacherSet.find(params[:id])
+    teacher_set.admin_availability = false
+    teacher_set.save
+    if request.format == :html
+      redirect_to admin_teacher_set_path(teacher_set)
+    else
+      render js: "makeAvailableTeacherSet(#{teacher_set.id}, false);"
+    end
+  end
+
+  form do |f|
+    f.semantic_errors *f.object.errors.keys
     f.inputs do
-      f.has_many :books, allow_destroy: false do |cf|
-        cf.semantic_errors *cf.object.errors.keys
-=begin
-        if cf.object.errors[:base].count > 0
-          cf.object.errors[:base].each do |e|
-            e.matching_api_items.each do |t|
-              # f.inline_errors_for :base
-              # cf.div 'Title', :type=>:radio
-              cf.input :catalog_choices
-            end
-          end
-        end
-=end
-        if cf.object.errors[:base].count > 0
-          coll = cf.object.errors[:base].first.matching_api_items.map do |t|
-            label = []
-            label << t['format']['name'] + ': ' unless t['format'].nil? || t['format']['name'].nil?
-            label << t['title'] if t['title']
-            label << 'by ' + t['authors'].map { |a| a['name'] }.join('; ') unless t['authors'].nil? || t['authors'].empty?
-            label << ' (isbn ' + t['isbns'].first + ')' unless t['isbns'].nil?
-            label = label.join ' '
-            label = label.truncate 80
-            biblio_id = t['id']
-            [label, biblio_id]
-          end
-          coll << ['None of these', '']
-          cf.input :catalog_choice, :label => 'Please Select Item', :as => :radio, :collection => coll, :input_html => {:data => {:titles => cf.object.errors[:base].first.matching_api_items}}
-        end
-
-        if !cf.object.id.nil?
-          cf.input :title, :input_html => {:disabled => true}
-          cf.input :_destroy, :as => :boolean, :label => "Delete?"
-
-        else
-          cf.input :title
-          cf.input :statement_of_responsibility, :label => 'Author Last Name', :input_html => { :rows=> 3 }
-          cf.input :isbn, :label => 'ISBN (if known)'
-        end
-        cf.form_buffers.last
-      end
+      f.input :total_copies
+      f.input :available_copies
+      f.input :admin_availability, label: 'Available'
     end
     f.actions
   end
@@ -157,6 +139,8 @@ ActiveAdmin.register TeacherSet do
       row 'Physical Description' do teacher_set_version.physical_description end
       row 'Publisher' do teacher_set_version.publisher end
       row 'Series' do teacher_set_version.series end
+      row 'Total Copies' do teacher_set_version.total_copies end
+      row 'Available Copies' do teacher_set_version.available_copies end
     end
 
     panel 'Holds' do

--- a/app/controllers/api/v01/bibs_controller.rb
+++ b/app/controllers/api/v01/bibs_controller.rb
@@ -9,7 +9,7 @@ class Api::V01::BibsController < ApplicationController
   def create_or_update_teacher_sets
     error_code_and_message = validate_request
     if error_code_and_message.any?
-      AdminMailer.failed_bibs_controller_api_request(@request_body, error_code_and_message, action_name)
+      AdminMailer.failed_bibs_controller_api_request(@request_body, error_code_and_message, action_name).deliver
       render_error(error_code_and_message)
     end
     return if error_code_and_message.any?
@@ -25,7 +25,7 @@ class Api::V01::BibsController < ApplicationController
       physical_description = var_field('300')
       description = var_field('520')
       if bnumber.blank? || title.blank? || physical_description.blank? || description.blank?
-        AdminMailer.teacher_set_update_missing_required_fields(bnumber, title, physical_description, description)
+        AdminMailer.teacher_set_update_missing_required_fields(bnumber, title, physical_description, description).deliver
         next
       end
 
@@ -61,7 +61,7 @@ class Api::V01::BibsController < ApplicationController
   def delete_teacher_sets
     error_code_and_message = validate_request
     if error_code_and_message.any?
-      AdminMailer.failed_bibs_controller_api_request(@request_body, error_code_and_message, action_name)
+      AdminMailer.failed_bibs_controller_api_request(@request_body, error_code_and_message, action_name).deliver
       render_error(error_code_and_message)
       return
     end

--- a/app/mailers/hold_mailer.rb
+++ b/app/mailers/hold_mailer.rb
@@ -14,13 +14,13 @@ class HoldMailer < ActionMailer::Base
       emails = AdminUser.pluck(:email)
       LogWrapper.log('DEBUG', {
         'message' => "About to send hold order admin notification email on #{@teacher_set.title or 'unknown'} to #{@user.email or 'unknown'}",
-        'method' => 'HoldMailer teacher_set_update_missing_required_fields'
+        'method' => 'HoldMailer admin_notification'
       })
       mail(:to => emails, :subject => "New Order from #{@user.email or 'unknown'} for #{@teacher_set.title or 'unknown'}")
     rescue => exception
       LogWrapper.log('ERROR', {
         'message' => "Cannot send hold order admin notification email.  Backtrace=#{exception.backtrace}.",
-        'method' => 'HoldMailer teacher_set_update_missing_required_fields'
+        'method' => 'HoldMailer admin_notification'
       })
       raise exception
     end

--- a/app/models/teacher_set.rb
+++ b/app/models/teacher_set.rb
@@ -9,7 +9,7 @@ class TeacherSet < ActiveRecord::Base
   attr_accessible :slug, :grade_begin, :grade_end, :availability, :call_number, :description, :details_url, :edition, :id,
                   :isbn, :language, :lexile_begin, :lexile_end, :notes, :physical_description, :primary_language, :publication_date,
                   :publisher, :series, :statement_of_responsibility, :sub_title, :title, :books_attributes,
-                  :available_copies, :total_copies, :primary_subject, :bnumber, :set_type, :contents, :last_book_change
+                  :available_copies, :total_copies, :primary_subject, :bnumber, :set_type, :contents, :last_book_change, :admin_availability
 
   attr_accessor :subject, :subject_key, :suitabilities_string, :note_summary, :note_string, :slug
 

--- a/app/views/admin_mailer/failed_bibs_controller_api_request.html.erb
+++ b/app/views/admin_mailer/failed_bibs_controller_api_request.html.erb
@@ -1,6 +1,5 @@
-<p>Bib Number: <%= @bnumber %></p>
-<p>Bib Number: <%= @bnumber %></p>
-<p>Title: <%= @title %></p>
-<p>Physical Description: <%= @physical_description %></p>
-<p>Description: <%= @description %></p>
+A bibs controller API request failed with this data:<br>
+<br>
+<p>Action Name: <%= @action_name %></p>
+<p>Error Code and Message: <%= @error_code_and_message %></p>
 <p>Request Body: <%= @request_body %></p>

--- a/app/views/admin_mailer/teacher_set_update_missing_required_fields.html.erb
+++ b/app/views/admin_mailer/teacher_set_update_missing_required_fields.html.erb
@@ -1,0 +1,6 @@
+The teacher set update is missing at least one of these required fields:<br>
+<br>
+<p>Bib Number: <%= @bnumber %></p>
+<p>Title: <%= @title %></p>
+<p>Physical Description: <%= @physical_description %></p>
+<p>Description: <%= @description %></p>

--- a/app/views/teacher_sets/_availability_links_container.html.erb
+++ b/app/views/teacher_sets/_availability_links_container.html.erb
@@ -1,14 +1,14 @@
-<div id="make-available-teacher-set-<%= teacher_set.id %>-container"
+<span id="make-available-teacher-set-<%= teacher_set.id %>-container"
      style="<%= !teacher_set.admin_availability? ? '' : 'display:none;' %> <%= (action == 'index' ? 'margin-left:20px;' : '') %>">
   <a href="<%= make_available_admin_teacher_set_path(teacher_set) %>" data-method="put" data-remote="true">
     <%= image_tag('unchecked.png', height: 20, width: 20, alt: '') %>
     <%= (action == 'show' ? "<span style='position:relative; top:-5px; right:-3px'>Unavailable</span>" : '').html_safe %>
   </a>
-</div>
-<div id="make-unavailable-teacher-set-<%= teacher_set.id %>-container"
+</span>
+<span id="make-unavailable-teacher-set-<%= teacher_set.id %>-container"
      style="<%= teacher_set.admin_availability? ? '' : 'display:none;' %> <%= (action == 'index' ? 'margin-left:20px;' : '') %>">
   <a href="<%= make_unavailable_admin_teacher_set_path(teacher_set) %>" data-method="put" data-remote="true">
     <%= image_tag('checked.png', height: 20, width: 20, alt: '') %>
     <%= (action == 'show' ? "<span style='position:relative; top:-5px; right:-3px'>Available</span>" : '').html_safe %>
   </a>
-</div>
+</span>

--- a/app/views/teacher_sets/_edit_button_container.html.erb
+++ b/app/views/teacher_sets/_edit_button_container.html.erb
@@ -1,0 +1,9 @@
+<a href="<%= edit_admin_teacher_set_path(teacher_set) %>" style="padding:16px 30px; position:relative; top:-7px;">
+  <span style="position:relative; top:2px;">Edit Teacher Set</span>
+</a>
+<style>
+  /* This will hide the default edit button which is not as tall as the button to make available/unavailable (due to checkbox icon). */
+  .action_item:nth-of-type(1) {
+    display:none;
+  }
+</style>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,4 +34,6 @@ MyLibraryNYC::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  config.action_mailer.perform_deliveries = false
 end


### PR DESCRIPTION
Kevin mentioned we need to make total_copies and available_copies editable.

# Bring edit button back
<img width="1440" alt="screen shot 2018-10-22 at 2 45 41 pm" src="https://user-images.githubusercontent.com/1825103/47312373-2c891b00-d60a-11e8-9714-3e5bd67e6467.png">

# Enable editing of total copies, available copies, and available boolean
<img width="1423" alt="screen shot 2018-10-22 at 2 52 12 pm" src="https://user-images.githubusercontent.com/1825103/47312372-2c891b00-d60a-11e8-851d-df173ea11911.png">
