### PR TITLE
Show available button for available teacher sets

### DIFF
--- a/app/admin/teacher_sets.rb
+++ b/app/admin/teacher_sets.rb
@@ -22,7 +22,7 @@ ActiveAdmin.register TeacherSet do
     column :title do |teacher_set|
       link_to(teacher_set.title, admin_teacher_set_path(teacher_set))
     end
-    column('Available', :admin_availability, sortable: :admin_availability) do |teacher_set|
+    column('Available', :availability, sortable: :availability) do |teacher_set|
       render(partial: 'teacher_sets/availability_links_container', locals: { teacher_set: teacher_set, action: 'index' })
     end
     column :created_at
@@ -46,7 +46,7 @@ ActiveAdmin.register TeacherSet do
 
   member_action :make_available, method: :put do
     teacher_set = TeacherSet.find(params[:id])
-    teacher_set.admin_availability = true
+    teacher_set.availability = true
     teacher_set.save
     if request.format == :html
       redirect_to admin_teacher_set_path(teacher_set)
@@ -57,18 +57,7 @@ ActiveAdmin.register TeacherSet do
 
   member_action :make_unavailable, method: :put do
     teacher_set = TeacherSet.find(params[:id])
-    teacher_set.admin_availability = false
-    teacher_set.save
-    if request.format == :html
-      redirect_to admin_teacher_set_path(teacher_set)
-    else
-      render js: "makeAvailableTeacherSet(#{teacher_set.id}, false);"
-    end
-  end
-
-  member_action :make_unavailable, method: :put do
-    teacher_set = TeacherSet.find(params[:id])
-    teacher_set.admin_availability = false
+    teacher_set.availability = false
     teacher_set.save
     if request.format == :html
       redirect_to admin_teacher_set_path(teacher_set)
@@ -82,7 +71,7 @@ ActiveAdmin.register TeacherSet do
     f.inputs do
       f.input :total_copies
       f.input :available_copies
-      f.input :admin_availability, label: 'Available'
+      f.input :availability, label: 'Available'
     end
     f.actions
   end
@@ -110,9 +99,6 @@ ActiveAdmin.register TeacherSet do
       teacher_set_version = teacher_set
     end
 
-    # Availability on the line below was based on item availability and set by the scraper.
-    # Now that the scraper is turned off, we use admin_availability, set in the admin dashboard.
-    # h2 "Availability: #{teacher_set.availability}"
     attributes_table do
       row 'Biblio page' do link_to(teacher_set_version.details_url, teacher_set_version.details_url, target:'_blank') end
       row 'Call Number' do teacher_set_version.call_number end

--- a/app/assets/javascripts/controllers/TeacherSetDetailCtrl.js
+++ b/app/assets/javascripts/controllers/TeacherSetDetailCtrl.js
@@ -13,13 +13,13 @@ app.controller('TeacherSetDetailCtrl', ['$scope', '$routeParams', '$http', '$loc
 
     $http.get('/teacher_sets/'+$scope.teacher_set_id+'.json').success(function(data) {
       $scope.ts = data.teacher_set;
-      $scope.is_available = (data.teacher_set.availability=="available");
+      $scope.is_available = data.teacher_set.availability == 'available';
+      $scope.ts.availability_string = data.teacher_set.availability;
       $scope.active_hold = data.teacher_set.active_hold;
       $scope.ts.teacher_set_notes = data.teacher_set.teacher_set_notes
       $scope.ts.books = data.teacher_set.books
       $scope.user = data.teacher_set.user
       $scope.loaded = true;
-
     });
 
     $scope.autoReserve = function() {

--- a/app/models/teacher_set.rb
+++ b/app/models/teacher_set.rb
@@ -9,7 +9,7 @@ class TeacherSet < ActiveRecord::Base
   attr_accessible :slug, :grade_begin, :grade_end, :availability, :call_number, :description, :details_url, :edition, :id,
                   :isbn, :language, :lexile_begin, :lexile_end, :notes, :physical_description, :primary_language, :publication_date,
                   :publisher, :series, :statement_of_responsibility, :sub_title, :title, :books_attributes,
-                  :available_copies, :total_copies, :primary_subject, :bnumber, :set_type, :contents, :last_book_change, :admin_availability
+                  :available_copies, :total_copies, :primary_subject, :bnumber, :set_type, :contents, :last_book_change
 
   attr_accessor :subject, :subject_key, :suitabilities_string, :note_summary, :note_string, :slug
 
@@ -732,10 +732,5 @@ class TeacherSet < ActiveRecord::Base
     teacher_set_notes_string.split(',').each do |note_content|
       TeacherSetNote.create(teacher_set_id: self.id, content: note_content)
     end
-  end
-
-  # Override availability (set by scraper) with admin_availability (set in admin dashboard)
-  def availability
-    return self.admin_availability
   end
 end

--- a/app/views/teacher_sets/_availability_links_container.html.erb
+++ b/app/views/teacher_sets/_availability_links_container.html.erb
@@ -1,12 +1,12 @@
 <span id="make-available-teacher-set-<%= teacher_set.id %>-container"
-     style="<%= !teacher_set.admin_availability? ? '' : 'display:none;' %> <%= (action == 'index' ? 'margin-left:20px;' : '') %>">
+     style="<%= !teacher_set.availability? ? '' : 'display:none;' %> <%= (action == 'index' ? 'margin-left:20px;' : '') %>">
   <a href="<%= make_available_admin_teacher_set_path(teacher_set) %>" data-method="put" data-remote="true">
     <%= image_tag('unchecked.png', height: 20, width: 20, alt: '') %>
     <%= (action == 'show' ? "<span style='position:relative; top:-5px; right:-3px'>Unavailable</span>" : '').html_safe %>
   </a>
 </span>
 <span id="make-unavailable-teacher-set-<%= teacher_set.id %>-container"
-     style="<%= teacher_set.admin_availability? ? '' : 'display:none;' %> <%= (action == 'index' ? 'margin-left:20px;' : '') %>">
+     style="<%= teacher_set.availability? ? '' : 'display:none;' %> <%= (action == 'index' ? 'margin-left:20px;' : '') %>">
   <a href="<%= make_unavailable_admin_teacher_set_path(teacher_set) %>" data-method="put" data-remote="true">
     <%= image_tag('checked.png', height: 20, width: 20, alt: '') %>
     <%= (action == 'show' ? "<span style='position:relative; top:-5px; right:-3px'>Available</span>" : '').html_safe %>

--- a/db/migrate/20181018221847_add_admin_availability_to_teacher_sets.rb
+++ b/db/migrate/20181018221847_add_admin_availability_to_teacher_sets.rb
@@ -1,5 +1,0 @@
-class AddAdminAvailabilityToTeacherSets < ActiveRecord::Migration
-  def change
-    add_column :teacher_sets, :admin_availability, :boolean, default: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-
-ActiveRecord::Schema.define(:version => 20181022145330) do
+ActiveRecord::Schema.define(:version => 20181023165547) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -195,7 +194,6 @@ ActiveRecord::Schema.define(:version => 20181022145330) do
     t.string   "set_type",                    :limit => 20
     t.text     "contents"
     t.string   "last_book_change"
-    t.boolean  "admin_availability",                        :default => true
   end
 
   add_index "teacher_sets", ["availability"], :name => "index_teacher_sets_availaibilty"


### PR DESCRIPTION
When we change a teacher set's `availability` attribute from "unavailable" to "available", the set becomes available in the view.

<img width="895" alt="screen shot 2018-10-23 at 6 10 36 pm" src="https://user-images.githubusercontent.com/1825103/47393938-07baa380-d6ef-11e8-98c6-b13476c4d4c0.png">
<img width="903" alt="screen shot 2018-10-23 at 6 10 20 pm" src="https://user-images.githubusercontent.com/1825103/47393939-07baa380-d6ef-11e8-9863-83e2b081b678.png">
