### PR TITLE
Adding Nginx timeout

### DIFF
--- a/.ebextensions/09_nginx_timeout.conf
+++ b/.ebextensions/09_nginx_timeout.conf
@@ -1,0 +1,15 @@
+files:
+  “/etc/nginx/conf.d/01-timeout.conf”:
+     mode: “000644”
+     owner: root
+     group: root
+     content: |
+       keepalive_timeout 300s;
+       # proxy_connect_timeout 120s;
+       # proxy_send_timeout 120s; 
+       # proxy_read_timeout 120s; 
+       # fastcgi_send_timeout 120s; 
+       # fastcgi_read_timeout 120s;
+container_commands:
+  nginx_reload:
+     command: “sudo service nginx reload”


### PR DESCRIPTION
This is to prep the new stacks for unified MyLibraryNYCApp. The Nginx timeout was initially added manually. This is to integrate as part of the new elastic beanstalk instances.