### PR TITLE
Merge: development -> qa: added rake task to run all unit tests in one process, and made travis…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# Coverage reports produced by SimpleCov
+/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,7 @@ script:
 - psql -c "CREATE DATABASE mln_test;" -U postgres
 - bundle exec rake db:migrate RAILS_ENV=test # 2019-10-16: added to fix errors when upgrading rails env
 - bundle exec rake db:migrate
-- ruby -Itest test/unit/user_test.rb
-- ruby -Itest test/unit/book_test.rb
-- ruby -Itest test/unit/teacher_set_test.rb
-- ruby -Itest test/unit/ingest_rake_task_test.rb
-- ruby -Itest test/integration/user_flow_test.rb
-- ruby -Itest test/functional/api/v01/bibs_controller_test.rb
+- bundle exec rake combined_tests:test
 deploy:
 - provider: elasticbeanstalk
   skip_cleanup: true

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'yaml_db'
 
 group :assets do # Gems used only for assets and not required in production environments by default.
   gem 'sass-rails'
-  gem 'coffee-rails'  
+  gem 'coffee-rails'
   gem 'uglifier', '>= 1.0.3'
 end
 
@@ -58,5 +58,6 @@ end
 
 group :test do
   gem 'minitest', '~> 5.6.1'
+  gem 'simplecov', '~> 0.17.1'
   gem 'database_cleaner'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -884,6 +884,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    docile (1.3.2)
     erubis (2.7.0)
     execjs (2.7.0)
     faker (2.5.0)
@@ -1050,6 +1051,11 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     slop (3.6.0)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
@@ -1126,6 +1132,7 @@ DEPENDENCIES
   rails (= 5.0.7.1)
   rubocop (~> 0.59.1)
   sass-rails
+  simplecov (~> 0.17.1)
   test-unit
   uglifier (>= 1.0.3)
   webmock

--- a/lib/tasks/combined_tests.rake
+++ b/lib/tasks/combined_tests.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# our code runs without gem_tasks, but it is the standard line to include.
+# if have issues, bring the line back into code.
+# require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::Task['test:run'].clear
+
+namespace :combined_tests do
+
+  desc "Run tests"
+  Rake::TestTask.new do |t|
+    t.libs << "lib"
+    t.libs << "test"
+
+    # if we let rake run all tests, then some of the tests fail due to age.
+    # t.test_files = FileList['test/**/*.rb']
+
+    # for now, specify the test file to run.
+    # this will also help automate for travis
+    t.test_files = Rake::FileList[
+      'test/unit/teacher_set_test.rb',
+      'test/unit/ingest_rake_task_test.rb',
+      'test/integration/user_flow_test.rb',
+      'test/functional/exceptions_controller_test.rb',
+      'test/functional/api/v01/bibs_controller_test.rb',
+      'test/unit/user_test.rb', 'test/unit/book_test.rb'
+    ].shuffle
+
+    t.verbose = false
+  end
+
+  # set the test task as default for safety
+  # task default: :test
+end

--- a/test/functional/exceptions_controller_test.rb
+++ b/test/functional/exceptions_controller_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ExceptionsControllerTest < ActionController::TestCase
+  # TODO: get is returning its own error right now, fix.
+
+  #  test 'render_error' do
+  #    get :render_error
+  #    assert response.body.include? "We've encountered an error."
+  #  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+# Note: minimum coverage config can also maybe happen outside, and before the start block.
+SimpleCov.start 'rails' do
+  add_filter '/bin/'
+  add_filter '/db/'
+  add_filter '/test/' # for minitest
+end
+# fail unit tests if total coverage dips below acceptable limit
+SimpleCov.minimum_coverage 25
+# fail unit tests if any file's individual coverage dips below acceptable limit
+SimpleCov.minimum_coverage_by_file 0
+
+
 ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
@@ -23,6 +36,7 @@ require 'stringio'
 require 'active_support'
 require 'active_support/core_ext'
 require 'logger'
+
 
 MODIFIED_BOOK_JSON_FOR_ISBN_9782917623268 = '{
   "data": [


### PR DESCRIPTION
… fail if coverage report falls below min limit(#556)

* added rake task to run unit tests in one process

* brought back test that shoud not have been deleted

* fixed rubocop complaints

* fixing more rubocop

* fixing more rubocop

* add coverage filter to travis, to fail when coverage drops below x%

* added simplecov gem for coverage reporting

* switching to trying to filter on coverage percentage within simplecov config

* trying again if coverage command works in travis for rails

* moved min coverage line

* moved coverage limit to inside simplecov start block

* moved coverage limit to inside simplecov start block

* moved simplecov config to start of helper file

* asked git to ignore the generated coverage reports