### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,9 @@ deploy:
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_PRODUCTION"
   region: us-east-1
   app: my-library-nyc-app
-  env: my-library-nyc-app-production25
+  env: my-library-nyc-app-production
   bucket_name: elasticbeanstalk-us-east-1-946183545209
-  bucket_path: my-library-nyc-app-production25
+  bucket_path: my-library-nyc-app-production
   on:
     repo: NYPL/MyLibraryNYCApp
     branch: master


### PR DESCRIPTION
The Elastic Beanstalk instance went through a rebuild, and the environment name has changed from `my-library-nyc-app-production25` to `my-library-nyc-app-production`. It is a minor change on `env` and `bucket_path` to ensure subsequent push to `master` branch do not cause failure. Please review. Thank you!