### PR TITLE
Add Log Rotation Configuration

### DIFF
--- a/.ebextensions/10_add_logroration.config
+++ b/.ebextensions/10_add_logroration.config
@@ -1,0 +1,13 @@
+files:
+    "/etc/logrotate.d/logrotate.elasticbeanstalk.mylibnyc.conf":
+        mode: "000655"
+        owner: root
+        group: root
+        content: |
+            /var/app/current/log/*.log {
+                rotate 14
+                size 10M
+                daily
+                compress
+                delaycompress
+            }


### PR DESCRIPTION
This is a preliminary configuration change which can be adjusted.

Adds a file to the .ebextensions configuration to allow logrotate.d to rotate and compress log files for the MyLibraryNYCApp. This will help to alleviate any potential disk space issues by curtailing the growth of log files over time.

All logs are also being sent to CloudWatch.