### PR TITLE
Increasing root volume to 64GB.

### DIFF
--- a/.ebextensions/001-filesystem.config
+++ b/.ebextensions/001-filesystem.config
@@ -1,0 +1,4 @@
+option_settings:
+  aws:autoscaling:launchconfiguration:
+    RootVolumeType: gp2
+    RootVolumeSize: "64"


### PR DESCRIPTION
This pull request will increase default disk size of all Beanstalk EC2 instances to 64 GB.

The purpose of the root volume size increase is to accommodate upgraded Ruby/React MyLibraryNYC application. 

Success criteria is to be able to see the configuration containing 64 GB for instance disk size, and while within the EC2 instance, seeing that `df -h` would return disk size as 64GB