### PR TITLE
SEB-2267 Update logrotation to hourly checks

### DIFF
--- a/.ebextensions/10_add_logroration.config
+++ b/.ebextensions/10_add_logroration.config
@@ -1,13 +1,16 @@
 files:
-    "/etc/logrotate.d/logrotate.elasticbeanstalk.mylibnyc.conf":
-        mode: "000655"
+    "/etc/logrotate.elasticbeanstalk.hourly/logrotate.elasticbeanstalk.mylibnyc.conf":
+        mode: "000644"
         owner: root
         group: root
         content: |
             /var/app/current/log/*.log {
+                missingok
+                notifempty
                 rotate 14
                 size 10M
-                daily
                 compress
-                delaycompress
+                copytruncate
+                dateext
+                dateformat %s
             }


### PR DESCRIPTION
Moves the log rotation configuration to the hourly directory and updates some of the options for rotation. The current configuration is being applied inconsistently and this attempts to rectify that. When the rotation rules are not applied, the log files continue to grow until the instance is replaced and a new log file is started.