### PR TITLE
TGR fix a migration for compatibility

### DIFF
--- a/db/migrate/20180920201052_create_versions.rb
+++ b/db/migrate/20180920201052_create_versions.rb
@@ -19,8 +19,8 @@ class CreateVersions < ActiveRecord::Migration[4.2]
   TEXT_BYTES = 1_073_741_823
 
   def change
-    create_table :versions, versions_table_options do |t|
-      t.string   :item_type, item_type_options
+    create_table :versions, **versions_table_options do |t|
+      t.string   :item_type, **item_type_options
       t.integer  :item_id,   null: false, limit: 8
       t.string   :event,     null: false
       t.string   :whodunnit


### PR DESCRIPTION
This PR fixes an ActiveRecord migration for compatibility with Rails 7.x. Now, you should be able to do something like `RAILS_ENV=test bundle exec rake db:drop db:create db:migrate` in a webapp container without encountering any errors.