### PR TITLE
Update hold status directly, skipping potentially failed validation

### DIFF
--- a/app/models/hold_change.rb
+++ b/app/models/hold_change.rb
@@ -40,8 +40,7 @@ class HoldChange < ActiveRecord::Base
 
   def update_hold
     # puts "updating hold status: ", hold.status, status
-    hold.status = status
-    hold.save
+    hold.update_columns(status: status)
   end
 
 end


### PR DESCRIPTION
Original bug/ticket - [SWIS-1]

I believe the `hold.save` call is failing silently due to validation on the `Hold` model failing because of the missing/invalid associated teacher set. 

This updates to use `update_columns` which [skips validation](https://apidock.com/rails/v3.2.13/ActiveRecord/Persistence/update_column) and should succeed regardless. 

[SWIS-1]: https://newyorkpubliclibrary.atlassian.net/browse/SWIS-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ