### PR TITLE
Use syndetics for covers and isbn directly

### DIFF
--- a/app/admin/books.rb
+++ b/app/admin/books.rb
@@ -84,7 +84,11 @@ ActiveAdmin.register Book do
   end
 
   sidebar :Image, :only => :show do
-    image_tag book.image_uri :medium
+    if book && book.image_uri.present?
+      image_tag book.image_uri :medium
+    else
+      "No image available"
+    end
   end
 
 end

--- a/app/assets/javascripts/active_admin_custom.js
+++ b/app/assets/javascripts/active_admin_custom.js
@@ -104,7 +104,7 @@ function activateSchool(schoolId, activate) {
   
       $.each(el.data('titles'), function(i, t) {
         if(t['isbns'])
-          image_uris[t['id']] = 'http://contentcafe2.btol.com/ContentCafe/Jacket.aspx?&userID=NYPL49807&password=CC68707&content=M&Return=1&Type=S&Value=' + t['isbns'][0];
+          image_uris[t["id"]] = "https://secure.syndetics.com/index.aspx?isbn=" + t["isbns"][0] + "/SC.gif&client=nyplvega&type=hw7";
         title_uris[t['id']] = t['details_url']
       });
       // console.log("set image uri: ", image_uris, title_uris);

--- a/app/controllers/teacher_sets_controller.rb
+++ b/app/controllers/teacher_sets_controller.rb
@@ -151,7 +151,7 @@ class TeacherSetsController < ApplicationController
 
     # limits book titles to unique ones to mask the problem we've been having
     # with the teacher_sets detail page puling up duplicate child book records.
-    ts_books = @set.books.select('DISTINCT ON (books.cover_uri) books.cover_uri, books.id, books.title')
+    ts_books = @set.books.select('DISTINCT ON (books.cover_uri) books.cover_uri, books.id, books.title, books.isbn')
 
     # Max copies value is configured in elastic beanstalk.
     # Max_copies_requestable is the maximum number of teachersets can request.

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -77,15 +77,20 @@ class Book < ActiveRecord::Base
 
 
   def image_uri(size=:small)
-    return nil if cover_uri.nil?
+    return nil if isbn.nil?
 
-    deriv = 'S'
-    deriv = 'M' if size == :medium
-    deriv = 'L' if size == :large
+    deriv = 'SC'
+    deriv = 'MC' if size == :medium
+    deriv = 'LC' if size == :large
 
-    cover_uri.sub /Type=L/, "Type=#{deriv}"
+    "https://secure.syndetics.com/index.aspx?isbn=#{isbn}/#{deriv}.gif&client=nyplvega&type=hw7"
   end
 
+  def cover_uri
+    return nil if isbn.nil?
+
+    "https://secure.syndetics.com/index.aspx?isbn=#{isbn}/MC.gif&client=nyplvega&type=hw7"
+  end
 
   # def update_from_catalog_item(item)
   #   self.update :details_url => item['details_url']


### PR DESCRIPTION
We are storing the legacy ContentCafe `cover_uri` in the books database, but luckily we also have `isbn` available to construct a syndetics url. 

This change ignores the value stored in the database by overriding the `cover_uri` getter, as well as updating the `image_uri` method to use syndetics and the `isbn` directly. However this means we need to also get the isbn when retrieving the cover_uri in `[teacher_sets_controller.rb](https://github.com/NYPL/MyLibraryNYCApp/compare/SWIS-149/cover-imgs?expand=1#diff-f09266c1ff78f800adc963f955b5002a4f4e474742cbda2d8675bc9a34a37141)`

Additionally, we updated the admin panel UI to use new covers. 