### PR TITLE
[SWIS-149] Migrate to Syndetics for cover images

### DIFF
--- a/app/admin/books.rb
+++ b/app/admin/books.rb
@@ -84,7 +84,11 @@ ActiveAdmin.register Book do
   end
 
   sidebar :Image, :only => :show do
-    image_tag book.image_uri :medium
+    if book && book.image_uri.present?
+      image_tag book.image_uri :medium
+    else
+      "No image available"
+    end
   end
 
 end

--- a/app/assets/javascripts/active_admin_custom.js
+++ b/app/assets/javascripts/active_admin_custom.js
@@ -104,7 +104,7 @@ function activateSchool(schoolId, activate) {
   
       $.each(el.data('titles'), function(i, t) {
         if(t['isbns'])
-          image_uris[t['id']] = 'http://contentcafe2.btol.com/ContentCafe/Jacket.aspx?&userID=NYPL49807&password=CC68707&content=M&Return=1&Type=S&Value=' + t['isbns'][0];
+          image_uris[t["id"]] = "https://secure.syndetics.com/index.aspx?isbn=" + t["isbns"][0] + "/SC.gif&client=nyplvega&type=hw7";
         title_uris[t['id']] = t['details_url']
       });
       // console.log("set image uri: ", image_uris, title_uris);

--- a/app/controllers/teacher_sets_controller.rb
+++ b/app/controllers/teacher_sets_controller.rb
@@ -151,7 +151,7 @@ class TeacherSetsController < ApplicationController
 
     # limits book titles to unique ones to mask the problem we've been having
     # with the teacher_sets detail page puling up duplicate child book records.
-    ts_books = @set.books.select('DISTINCT ON (books.cover_uri) books.cover_uri, books.id, books.title')
+    ts_books = @set.books.select('DISTINCT ON (books.cover_uri) books.cover_uri, books.id, books.title, books.isbn')
 
     # Max copies value is configured in elastic beanstalk.
     # Max_copies_requestable is the maximum number of teachersets can request.

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -89,7 +89,7 @@ class Book < ActiveRecord::Base
   def cover_uri
     return nil if isbn.nil?
 
-    "https://secure.syndetics.com/index.aspx?isbn=#{isbn}/MC.gif&client=nyplvega&type=hw7"
+    "https://secure.syndetics.com/index.aspx?isbn=#{isbn}/LC.gif&client=nyplvega&type=hw7"
   end
 
   # def update_from_catalog_item(item)
@@ -190,7 +190,7 @@ class Book < ActiveRecord::Base
         description: var_field(book_attributes, '520'),
         physical_description: var_field(book_attributes, '300'),
         format: var_field(book_attributes, '020'),
-        cover_uri: "http://contentcafe2.btol.com/ContentCafe/Jacket.aspx?&userID=NYPL49807&password=CC68707&content=M&Return=1&Type=L&Value=#{isbn}",
+        cover_uri: "https://secure.syndetics.com/index.aspx?isbn=#{isbn}/LC.gif&client=nyplvega&type=hw7",
         bib_code_3: fixed_field(book_attributes, '31', true)
       )
     rescue => e

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -77,15 +77,20 @@ class Book < ActiveRecord::Base
 
 
   def image_uri(size=:small)
-    return nil if cover_uri.nil?
+    return nil if isbn.nil?
 
-    deriv = 'S'
-    deriv = 'M' if size == :medium
-    deriv = 'L' if size == :large
+    deriv = 'SC'
+    deriv = 'MC' if size == :medium
+    deriv = 'LC' if size == :large
 
-    cover_uri.sub /Type=L/, "Type=#{deriv}"
+    "https://secure.syndetics.com/index.aspx?isbn=#{isbn}/#{deriv}.gif&client=nyplvega&type=hw7"
   end
 
+  def cover_uri
+    return nil if isbn.nil?
+
+    "https://secure.syndetics.com/index.aspx?isbn=#{isbn}/MC.gif&client=nyplvega&type=hw7"
+  end
 
   # def update_from_catalog_item(item)
   #   self.update :details_url => item['details_url']


### PR DESCRIPTION
This moves us to using Syndetics for book covers, removing the now deprecated ContentCafe links. 

Ticket: [SWIS-149](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-149)

[SWIS-149]: https://newyorkpubliclibrary.atlassian.net/browse/SWIS-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ