### PR TITLE
Remove book and teacherset links to legacy catalog

### DIFF
--- a/app/javascript/components/TeacherSetBooks/TeacherSetBooks.jsx
+++ b/app/javascript/components/TeacherSetBooks/TeacherSetBooks.jsx
@@ -244,8 +244,6 @@ export default function TeacherSetBooks() {
   };
 
   let bookTitle = book.title ? book.title : "Book Title";
-  let legacyDetailUrl =
-    "http://legacycatalog.nypl.org/record=" + book.bnumber + "~S1";
 
   return (
     <TemplateAppContainer
@@ -407,14 +405,6 @@ export default function TeacherSetBooks() {
             )}
           </List>
 
-          <Link
-            className="tsDetailUrl"
-            href={legacyDetailUrl}
-            id="ts-book-page-details_url"
-            type="external"
-          >
-            View in catalog
-          </Link>
           <Heading
             marginTop="l"
             marginBottom="l"

--- a/app/javascript/components/TeacherSetDetails/TeacherSetDetails.jsx
+++ b/app/javascript/components/TeacherSetDetails/TeacherSetDetails.jsx
@@ -515,10 +515,6 @@ export default function TeacherSetDetails(props) {
     return teacherSet.availability === "available" ? "informative" : "neutral";
   };
 
-  const legacyDetailUrl = () => {
-    return "http://legacycatalog.nypl.org/record=" + teacherSet.bnumber + "~S1";
-  };
-
   const tsTitle = () => {
     return teacherSet.title ? teacherSet.title : "";
   };
@@ -792,14 +788,6 @@ export default function TeacherSetDetails(props) {
           {TeacherSetDescription()}
           {displayTeacherSetBooks()}
           {teacherSetListDetails(teacherSet)}
-          <Link
-            href={legacyDetailUrl()}
-            id="ts-page-details_url"
-            type="external"
-            marginTop="l"
-          >
-            View in catalog
-          </Link>
         </>
       }
       contentSidebar={orderTeacherSetsInfo()}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       RAILS_ENV=development bundle exec rake elasticsearch:delete_teacherset_index;
       RAILS_ENV=development bundle exec rake elasticsearch:create_teacherset_index;
       RAILS_ENV=development bundle exec rake seeds:teacher_sets;
+      yarn build --watch &
+      yarn build:css --watch &
       bundle exec rails server -b 0.0.0.0
       "
 

--- a/public/templates/books/detail.html
+++ b/public/templates/books/detail.html
@@ -27,7 +27,6 @@
       <dt ng-show="book.notes">Notes</dt>
       <dd>{{book.notes}}</dd>
     </dl>
-    <p ng-show="show_catalog_link"><a href="{{book.details_url}}" target="_blank">View in catalog</a></p>
   </div>
   
   <hr />

--- a/public/templates/teacher_sets/detail.html
+++ b/public/templates/teacher_sets/detail.html
@@ -94,7 +94,6 @@
           <dd>{{ts.isbn}}</dd>
           <dt ng-show="ts.series">Series</dt>
           <dd>{{ts.series}}</dd>
-          <dd><a href="{{ts.details_url}}" target="_blank">View in catalog</a></dd>
         </dl>
       </div>
       <a ng-show="moreList" ng-click="moreList = !moreList"><i class="fa fa-minus-circle"></i> Close</a>


### PR DESCRIPTION
This removes the "View in Catalog" links in both teacher sets and book details pages. These currently link to the legacy catalog which will no longer be accessible externally after the deprecation next week. 